### PR TITLE
Changing conformance criteria roll up count from a list to a table

### DIFF
--- a/dist/createOutput.js
+++ b/dist/createOutput.js
@@ -45,6 +45,20 @@ function createOutput(data, catalogData, templateType, templateString) {
             }
         }
     });
+    const getCatalogComponentLabel = (componentId) => {
+        if (catalogData.components) {
+            for (const component of catalogData.components) {
+                if (component.id === componentId) {
+                    if (component.label != "") {
+                        return component.label;
+                    }
+                    else {
+                        return "All";
+                    }
+                }
+            }
+        }
+    };
     handlebars_1.default.registerHelper("catalogComponentLabel", function (componentId) {
         if (catalogData.components) {
             for (const component of catalogData.components) {
@@ -61,7 +75,7 @@ function createOutput(data, catalogData, templateType, templateString) {
             }
         }
     });
-    handlebars_1.default.registerHelper("levelLabel", function (level) {
+    const getLevelLabel = (level) => {
         if (catalogData.terms) {
             for (const terms of catalogData.terms) {
                 if (terms.id === level) {
@@ -71,7 +85,8 @@ function createOutput(data, catalogData, templateType, templateString) {
         }
         // If a level is provided but has no matching terms, provide a default.
         return "Not Applicable";
-    });
+    };
+    handlebars_1.default.registerHelper("levelLabel", getLevelLabel);
     handlebars_1.default.registerHelper("standardsIncluded", function (standardChapters) {
         const result = [];
         for (const standardChapter of standardChapters) {
@@ -145,42 +160,88 @@ function createOutput(data, catalogData, templateType, templateString) {
         return levelCount;
     });
     handlebars_1.default.registerHelper("progressPerChapter", function (criterias) {
-        let supportCount = 0;
-        let partiallySupportCount = 0;
-        let doesNotSupportCount = 0;
-        let notApplicableCount = 0;
+        let tableHeader = "";
+        let tableHeaderMarkdownUnderline = "";
+        const tableCounts = [];
+        for (const component of criterias[0].components) {
+            if (templateType === "html") {
+                tableHeader += `<th>${getCatalogComponentLabel(component.name)}</th>`;
+            }
+            else {
+                tableHeader += ` | ${getCatalogComponentLabel(component.name)}`;
+                tableHeaderMarkdownUnderline += " | ---";
+            }
+            tableCounts[component.name] = [];
+        }
         for (const criteria of criterias) {
             if (criteria.components) {
                 for (const component of criteria.components) {
-                    if (component.adherence && component.adherence.level === "supports") {
-                        supportCount = supportCount + 1;
+                    if (component.adherence) {
+                        if (tableCounts[component.name] === undefined) {
+                            if (templateType === "html") {
+                                tableHeader += `<th>${getCatalogComponentLabel(component.name)}</th>`;
+                            }
+                            else {
+                                tableHeader += ` | ${getCatalogComponentLabel(component.name)}`;
+                                tableHeaderMarkdownUnderline += " | ---";
+                            }
+                            tableCounts[component.name] = [];
+                        }
+                        if (tableCounts[component.name][component.adherence.level]) {
+                            tableCounts[component.name][component.adherence.level] += 1;
+                        }
+                        else {
+                            tableCounts[component.name][component.adherence.level] = 1;
+                        }
                     }
-                    else if (component.adherence &&
-                        component.adherence.level === "partially-supports") {
-                        partiallySupportCount = partiallySupportCount + 1;
+                }
+            }
+        }
+        let tableBody = "";
+        if (catalogData.terms) {
+            for (const term of catalogData.terms) {
+                if (term.label != "" && term.id != "not-evaluated") {
+                    if (templateType === "html") {
+                        tableBody += `<tr><td>${getLevelLabel(term.id)}</td>`;
                     }
-                    else if (component.adherence &&
-                        component.adherence.level === "does-not-support") {
-                        doesNotSupportCount = doesNotSupportCount + 1;
+                    else {
+                        tableBody += `| ${getLevelLabel(term.id)}`;
                     }
-                    else if (component.adherence &&
-                        component.adherence.level === "not-applicable") {
-                        notApplicableCount = notApplicableCount + 1;
+                    for (const component in tableCounts) {
+                        if (templateType === "html") {
+                            if (tableCounts[component] && tableCounts[component][term.id]) {
+                                tableBody += `<td>${tableCounts[component][term.id]}</td>`;
+                            }
+                            else {
+                                tableBody += "<td>0</td>";
+                            }
+                        }
+                        else {
+                            if (tableCounts[component] && tableCounts[component][term.id]) {
+                                tableBody += ` | ${tableCounts[component][term.id]}`;
+                            }
+                            else {
+                                tableBody += " | 0";
+                            }
+                        }
+                    }
+                    if (templateType === "html") {
+                        tableBody += "</tr>";
+                    }
+                    else {
+                        tableBody += ` |
+`;
                     }
                 }
             }
         }
         if (templateType === "html") {
-            return new handlebars_1.default.SafeString(`<li>${supportCount} supported</li>
-        <li>${partiallySupportCount} partially supported</li>
-        <li>${doesNotSupportCount} not supported</li>
-        <li>${notApplicableCount} not applicable</li>`);
+            return new handlebars_1.default.SafeString(`<thead><tr><th>Conformance Level</th>${tableHeader}</tr></thead>${tableBody}`);
         }
         else {
-            return `- ${supportCount} supported
-- ${partiallySupportCount} partially supported
-- ${doesNotSupportCount} not supported
-- ${notApplicableCount} not applicable`;
+            return `| Conformance Level${tableHeader} |
+| ---${tableHeaderMarkdownUnderline} |
+${tableBody}`;
         }
     });
     handlebars_1.default.registerHelper("sanitizeMarkdown", function (text) {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -170,7 +170,7 @@ Current example OpenACRs that are tracked in this repository are in the `openacr
 
 OpenACRs:
 
-- drupal-10-15.yaml: Drupal 10 OpenACR.
+- drupal-10-16.yaml: Drupal 10 OpenACR.
 - drupal-9.yaml: Drupal 9 OpenACR.
 - govready-0.9.yaml
 - Moodle-3.yaml
@@ -180,7 +180,7 @@ OpenACRs:
 To regenerate the above OpenACR markdown and HTML reports run the following commands:
 
 ```bash
-npx ts-node src/openacr.ts output -f openacr/drupal-10-15.yaml -c catalog/2.4-edition-wcag-2.1-en.yaml -o openacr/drupal-10-15.html
+npx ts-node src/openacr.ts output -f openacr/drupal-10-16.yaml -c catalog/2.4-edition-wcag-2.1-en.yaml -o openacr/drupal-10-16.html
 npx ts-node src/openacr.ts output -f openacr/drupal-9.yaml -c catalog/2.4-edition-wcag-2.1-508-en.yaml -o openacr/drupal-9.html
 npx ts-node src/openacr.ts output -f openacr/drupal-9.yaml -c catalog/2.4-edition-wcag-2.1-508-en.yaml -o openacr/drupal-9.markdown
 npx ts-node src/openacr.ts output -f openacr/govready-0.9.yaml -c catalog/2.4-edition-wcag-2.0-508-en.yaml -o openacr/govready-0.9.html

--- a/openacr/Moodle-3.html
+++ b/openacr/Moodle-3.html
@@ -303,16 +303,49 @@
         </h3>
 
         <div id="success_criteria_level_a-summary">
-          <p>
-            Conformance to the 25 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>22 supported</li>
-            <li>1 partially supported</li>
-            <li>0 not supported</li>
-            <li>76 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 25 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>22</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>1</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>1</td>
+              <td>25</td>
+              <td>25</td>
+              <td>25</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -1513,16 +1546,49 @@
         </h3>
 
         <div id="success_criteria_level_aa-summary">
-          <p>
-            Conformance to the 13 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>9 supported</li>
-            <li>1 partially supported</li>
-            <li>0 not supported</li>
-            <li>38 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 13 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>9</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>1</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>2</td>
+              <td>13</td>
+              <td>12</td>
+              <td>11</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2130,16 +2196,34 @@
         </h3>
 
         <div id="success_criteria_level_aaa-summary">
-          <p>
-            Conformance to the 23 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>9 supported</li>
-            <li>5 partially supported</li>
-            <li>0 not supported</li>
-            <li>7 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 23 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>9</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>5</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>7</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2893,16 +2977,34 @@
         </div>
 
         <div id="functional_performance_criteria-summary">
-          <p>
-            Conformance to the 9 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>2 supported</li>
-            <li>0 partially supported</li>
-            <li>3 not supported</li>
-            <li>4 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 9 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>3</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>4</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -3217,16 +3319,34 @@
         </h3>
 
         <div id="support_documentation_and_services-summary">
-          <p>
-            Conformance to the 4 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>0 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>4 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 4 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>4</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">

--- a/openacr/Moodle-3.markdown
+++ b/openacr/Moodle-3.markdown
@@ -58,12 +58,14 @@ The terms used in the Conformance Level information are defined as follows:
 
 ### Table 1: Success Criteria, Level A
 
-Conformance to the 25 criteria listed below is distributed as follows:
+Conformance to the 25 criteria listed below is distributed within each category as follows:
 
-- 22 supported
-- 1 partially supported
-- 0 not supported
-- 76 not applicable
+| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
+| ------------------ | --- | -------------------- | -------- | -------------- |
+| Supports           | 22  | 0                    | 0        | 0              |
+| Partially Supports | 1   | 0                    | 0        | 0              |
+| Does Not Support   | 0   | 0                    | 0        | 0              |
+| Not Applicable     | 1   | 25                   | 25       | 25             |
 
 | Criteria                                                                                                           | Conformance Level                                                                                                                                                               | Remarks and Explanations                                                                                                                                                                                                                                                                                     |
 | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -98,12 +100,14 @@ Conformance to the 25 criteria listed below is distributed as follows:
 
 ### Table 2: Success Criteria, Level AA
 
-Conformance to the 13 criteria listed below is distributed as follows:
+Conformance to the 13 criteria listed below is distributed within each category as follows:
 
-- 9 supported
-- 1 partially supported
-- 0 not supported
-- 38 not applicable
+| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
+| ------------------ | --- | -------------------- | -------- | -------------- |
+| Supports           | 9   | 0                    | 0        | 0              |
+| Partially Supports | 1   | 0                    | 0        | 0              |
+| Does Not Support   | 0   | 0                    | 0        | 0              |
+| Not Applicable     | 2   | 13                   | 12       | 11             |
 
 | Criteria                                                                                                      | Conformance Level                                                                                                                                                               | Remarks and Explanations                                                                                                                                                                                                                           |
 | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -124,12 +128,14 @@ Conformance to the 13 criteria listed below is distributed as follows:
 
 ### Table 3: Success Criteria, Level AAA
 
-Conformance to the 23 criteria listed below is distributed as follows:
+Conformance to the 23 criteria listed below is distributed within each category as follows:
 
-- 9 supported
-- 5 partially supported
-- 0 not supported
-- 7 not applicable
+| Conformance Level  | Web |
+| ------------------ | --- |
+| Supports           | 9   |
+| Partially Supports | 5   |
+| Does Not Support   | 0   |
+| Not Applicable     | 7   |
 
 | Criteria                                                                                                | Conformance Level                              | Remarks and Explanations                                                                                                                                                                                                                                                                                                                                           |
 | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -168,12 +174,14 @@ Conformance to the 23 criteria listed below is distributed as follows:
 
 Notes: Not applicable.
 
-Conformance to the 9 criteria listed below is distributed as follows:
+Conformance to the 9 criteria listed below is distributed within each category as follows:
 
-- 2 supported
-- 0 partially supported
-- 3 not supported
-- 4 not applicable
+| Conformance Level  | All |
+| ------------------ | --- |
+| Supports           | 2   |
+| Partially Supports | 0   |
+| Does Not Support   | 3   |
+| Not Applicable     | 4   |
 
 | Criteria                                                                                                  | Conformance Level                   | Remarks and Explanations                                                                                                                               |
 | --------------------------------------------------------------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -197,12 +205,14 @@ Notes: Software accessibility criteria is not applicable.
 
 ### Chapter 6: Support Documentation and Services
 
-Conformance to the 4 criteria listed below is distributed as follows:
+Conformance to the 4 criteria listed below is distributed within each category as follows:
 
-- 0 supported
-- 0 partially supported
-- 0 not supported
-- 4 not applicable
+| Conformance Level  | All |
+| ------------------ | --- |
+| Supports           | 0   |
+| Partially Supports | 0   |
+| Does Not Support   | 0   |
+| Not Applicable     | 4   |
 
 | Criteria                                                                                                    | Conformance Level                 | Remarks and Explanations |
 | ----------------------------------------------------------------------------------------------------------- | --------------------------------- | ------------------------ |

--- a/openacr/NVDA-2018.html
+++ b/openacr/NVDA-2018.html
@@ -292,16 +292,49 @@
         </h3>
 
         <div id="success_criteria_level_a-summary">
-          <p>
-            Conformance to the 25 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>25 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>75 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 25 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>25</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>0</td>
+              <td>25</td>
+              <td>25</td>
+              <td>25</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -1411,16 +1444,49 @@
         </h3>
 
         <div id="success_criteria_level_aa-summary">
-          <p>
-            Conformance to the 13 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>13 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>39 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 13 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>13</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>0</td>
+              <td>13</td>
+              <td>13</td>
+              <td>13</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2013,16 +2079,39 @@
         </h3>
 
         <div id="success_criteria_level_aaa-summary">
-          <p>
-            Conformance to the 23 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>15 supported</li>
-            <li>7 partially supported</li>
-            <li>2 not supported</li>
-            <li>0 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 23 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Software</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>14</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>7</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>2</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2754,16 +2843,34 @@
         </h3>
 
         <div id="functional_performance_criteria-summary">
-          <p>
-            Conformance to the 9 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>9 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>0 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 9 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>9</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>0</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -3022,16 +3129,34 @@
         </h3>
 
         <div id="software-summary">
-          <p>
-            Conformance to the 24 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>23 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>1 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 24 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>23</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>1</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -3624,16 +3749,34 @@
         </h3>
 
         <div id="support_documentation_and_services-summary">
-          <p>
-            Conformance to the 5 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>5 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>0 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 5 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>5</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>0</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">

--- a/openacr/NVDA-2018.markdown
+++ b/openacr/NVDA-2018.markdown
@@ -53,12 +53,14 @@ The terms used in the Conformance Level information are defined as follows:
 
 ### Table 1: Success Criteria, Level A
 
-Conformance to the 25 criteria listed below is distributed as follows:
+Conformance to the 25 criteria listed below is distributed within each category as follows:
 
-- 25 supported
-- 0 partially supported
-- 0 not supported
-- 75 not applicable
+| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
+| ------------------ | --- | -------------------- | -------- | -------------- |
+| Supports           | 25  | 0                    | 0        | 0              |
+| Partially Supports | 0   | 0                    | 0        | 0              |
+| Does Not Support   | 0   | 0                    | 0        | 0              |
+| Not Applicable     | 0   | 25                   | 25       | 25             |
 
 | Criteria                                                                                                           | Conformance Level                                                                                                                                                     | Remarks and Explanations |
 | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
@@ -90,12 +92,14 @@ Conformance to the 25 criteria listed below is distributed as follows:
 
 ### Table 2: Success Criteria, Level AA
 
-Conformance to the 13 criteria listed below is distributed as follows:
+Conformance to the 13 criteria listed below is distributed within each category as follows:
 
-- 13 supported
-- 0 partially supported
-- 0 not supported
-- 39 not applicable
+| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
+| ------------------ | --- | -------------------- | -------- | -------------- |
+| Supports           | 13  | 0                    | 0        | 0              |
+| Partially Supports | 0   | 0                    | 0        | 0              |
+| Does Not Support   | 0   | 0                    | 0        | 0              |
+| Not Applicable     | 0   | 13                   | 13       | 13             |
 
 | Criteria                                                                                                      | Conformance Level                                                                                                                                                     | Remarks and Explanations |
 | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
@@ -115,12 +119,14 @@ Conformance to the 13 criteria listed below is distributed as follows:
 
 ### Table 3: Success Criteria, Level AAA
 
-Conformance to the 23 criteria listed below is distributed as follows:
+Conformance to the 23 criteria listed below is distributed within each category as follows:
 
-- 15 supported
-- 7 partially supported
-- 2 not supported
-- 0 not applicable
+| Conformance Level  | Web | Software |
+| ------------------ | --- | -------- |
+| Supports           | 14  | 1        |
+| Partially Supports | 7   | 0        |
+| Does Not Support   | 2   | 0        |
+| Not Applicable     | 0   | 0        |
 
 | Criteria                                                                                                | Conformance Level                                                             | Remarks and Explanations                                                                                                                                                                                                                                                     |
 | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -153,12 +159,14 @@ Conformance to the 23 criteria listed below is distributed as follows:
 
 ### Chapter 3: Functional Performance Criteria (FPC)
 
-Conformance to the 9 criteria listed below is distributed as follows:
+Conformance to the 9 criteria listed below is distributed within each category as follows:
 
-- 9 supported
-- 0 partially supported
-- 0 not supported
-- 0 not applicable
+| Conformance Level  | All |
+| ------------------ | --- |
+| Supports           | 9   |
+| Partially Supports | 0   |
+| Does Not Support   | 0   |
+| Not Applicable     | 0   |
 
 | Criteria                                                                                                  | Conformance Level           | Remarks and Explanations |
 | --------------------------------------------------------------------------------------------------------- | --------------------------- | ------------------------ |
@@ -178,12 +186,14 @@ Notes: Hardware accessibility criteria is not applicable.
 
 ### Chapter 5: Software
 
-Conformance to the 24 criteria listed below is distributed as follows:
+Conformance to the 24 criteria listed below is distributed within each category as follows:
 
-- 23 supported
-- 0 partially supported
-- 0 not supported
-- 1 not applicable
+| Conformance Level  | All |
+| ------------------ | --- |
+| Supports           | 23  |
+| Partially Supports | 0   |
+| Does Not Support   | 0   |
+| Not Applicable     | 1   |
 
 | Criteria                                                                                                                         | Conformance Level                 | Remarks and Explanations |
 | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ------------------------ |
@@ -214,12 +224,14 @@ Conformance to the 24 criteria listed below is distributed as follows:
 
 ### Chapter 6: Support Documentation and Services
 
-Conformance to the 5 criteria listed below is distributed as follows:
+Conformance to the 5 criteria listed below is distributed within each category as follows:
 
-- 5 supported
-- 0 partially supported
-- 0 not supported
-- 0 not applicable
+| Conformance Level  | All |
+| ------------------ | --- |
+| Supports           | 5   |
+| Partially Supports | 0   |
+| Does Not Support   | 0   |
+| Not Applicable     | 0   |
 
 | Criteria                                                                                                    | Conformance Level           | Remarks and Explanations |
 | ----------------------------------------------------------------------------------------------------------- | --------------------------- | ------------------------ |

--- a/openacr/Plone-5.html
+++ b/openacr/Plone-5.html
@@ -309,16 +309,49 @@
         </h3>
 
         <div id="success_criteria_level_a-summary">
-          <p>
-            Conformance to the 25 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>45 supported</li>
-            <li>1 partially supported</li>
-            <li>0 not supported</li>
-            <li>54 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 25 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>25</td>
+              <td>20</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+              <td>1</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>0</td>
+              <td>4</td>
+              <td>25</td>
+              <td>25</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -1439,16 +1472,49 @@
         </h3>
 
         <div id="success_criteria_level_aa-summary">
-          <p>
-            Conformance to the 13 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>31 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>18 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 13 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>13</td>
+              <td>10</td>
+              <td>0</td>
+              <td>8</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>0</td>
+              <td>3</td>
+              <td>12</td>
+              <td>3</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2023,16 +2089,34 @@
         </h3>
 
         <div id="success_criteria_level_aaa-summary">
-          <p>
-            Conformance to the 23 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>0 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>0 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 23 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>0</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2655,16 +2739,34 @@
         </h3>
 
         <div id="functional_performance_criteria-summary">
-          <p>
-            Conformance to the 9 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>8 supported</li>
-            <li>1 partially supported</li>
-            <li>0 not supported</li>
-            <li>0 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 9 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>8</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>0</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">

--- a/openacr/Plone-5.markdown
+++ b/openacr/Plone-5.markdown
@@ -57,12 +57,14 @@ The terms used in the Conformance Level information are defined as follows:
 
 ### Table 1: Success Criteria, Level A
 
-Conformance to the 25 criteria listed below is distributed as follows:
+Conformance to the 25 criteria listed below is distributed within each category as follows:
 
-- 45 supported
-- 1 partially supported
-- 0 not supported
-- 54 not applicable
+| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
+| ------------------ | --- | -------------------- | -------- | -------------- |
+| Supports           | 25  | 20                   | 0        | 0              |
+| Partially Supports | 0   | 1                    | 0        | 0              |
+| Does Not Support   | 0   | 0                    | 0        | 0              |
+| Not Applicable     | 0   | 4                    | 25       | 25             |
 
 | Criteria                                                                                                           | Conformance Level                                                                                                                                                         | Remarks and Explanations                                                                                                                                       |
 | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -94,12 +96,14 @@ Conformance to the 25 criteria listed below is distributed as follows:
 
 ### Table 2: Success Criteria, Level AA
 
-Conformance to the 13 criteria listed below is distributed as follows:
+Conformance to the 13 criteria listed below is distributed within each category as follows:
 
-- 31 supported
-- 0 partially supported
-- 0 not supported
-- 18 not applicable
+| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
+| ------------------ | --- | -------------------- | -------- | -------------- |
+| Supports           | 13  | 10                   | 0        | 8              |
+| Partially Supports | 0   | 0                    | 0        | 0              |
+| Does Not Support   | 0   | 0                    | 0        | 0              |
+| Not Applicable     | 0   | 3                    | 12       | 3              |
 
 | Criteria                                                                                                      | Conformance Level                                                                                                                                               | Remarks and Explanations |
 | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
@@ -119,12 +123,14 @@ Conformance to the 13 criteria listed below is distributed as follows:
 
 ### Table 3: Success Criteria, Level AAA
 
-Conformance to the 23 criteria listed below is distributed as follows:
+Conformance to the 23 criteria listed below is distributed within each category as follows:
 
-- 0 supported
-- 0 partially supported
-- 0 not supported
-- 0 not applicable
+| Conformance Level  | Web |
+| ------------------ | --- |
+| Supports           | 0   |
+| Partially Supports | 0   |
+| Does Not Support   | 0   |
+| Not Applicable     | 0   |
 
 | Criteria                                                                                                | Conformance Level                         | Remarks and Explanations |
 | ------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ------------------------ |
@@ -156,12 +162,14 @@ Conformance to the 23 criteria listed below is distributed as follows:
 
 ### Chapter 3: Functional Performance Criteria (FPC)
 
-Conformance to the 9 criteria listed below is distributed as follows:
+Conformance to the 9 criteria listed below is distributed within each category as follows:
 
-- 8 supported
-- 1 partially supported
-- 0 not supported
-- 0 not applicable
+| Conformance Level  | All |
+| ------------------ | --- |
+| Supports           | 8   |
+| Partially Supports | 1   |
+| Does Not Support   | 0   |
+| Not Applicable     | 0   |
 
 | Criteria                                                                                                  | Conformance Level                     | Remarks and Explanations                                                                                                  |
 | --------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |

--- a/openacr/drupal-10-16-simple.html
+++ b/openacr/drupal-10-16-simple.html
@@ -124,7 +124,9 @@
           Report
         </h1>
 
-        <div class="catalog-section">Based on VPAT® 2.4</div>
+        <div class="catalog-section">
+          Based on VPAT® 2.4 WCAG 2.1 and Revised Section 508 Edition
+        </div>
 
         <div class="product-section">
           <h2 id="name-of-product-version">
@@ -159,8 +161,8 @@
           </h2>
           <ul>
             <li>Report Date: 2023-05-12</li>
-            <li>Last Modified Date: 2023-05-16</li>
-            <li>Version: drupal-10-15</li>
+            <li>Last Modified Date: 2023-06-19</li>
+            <li>Version: drupal-10-16</li>
           </ul>
         </div>
 
@@ -228,11 +230,25 @@
               <li>Phone: (510) 408-7510</li>
               <li>
                 Website:
-                <a href="https://civicactions.com/"
-                  >https://civicactions.com/</a
-                >
+                <a href="https://civicactions.com">https://civicactions.com</a>
               </li>
             </ul>
+          </div>
+          <div class="vendor-section">
+            <h3 id="vendor">
+              Vendor Information
+              <a href="#vendor" class="header-anchor">
+                <span class="anchor-icon" aria-hidden="true">
+                  <svg focusable="false" aria-hidden="true" class="icon-link">
+                    <path
+                      d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+                    />
+                  </svg>
+                </span>
+                <span class="visuallyhidden">Anchor link</span>
+              </a>
+            </h3>
+            <ul></ul>
           </div>
         </div>
 
@@ -322,6 +338,25 @@
                   <ul>
                     <li>Table 1: Success Criteria, Level A</li>
                     <li>Table 2: Success Criteria, Level AA</li>
+                    <li>Table 3: Success Criteria, Level AAA</li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="https://www.access-board.gov/ict/" target="_blank"
+                    >Revised Section 508 standards published January 18, 2017
+                    and corrected January 22, 2018<span class="usa-sr-only">
+                      (opens in a new window or tab)</span
+                    ></a
+                  >
+                </td>
+                <td>
+                  <ul>
+                    <li>Chapter 3: Functional Performance Criteria (FPC)</li>
+                    <li>Chapter 4: Hardware</li>
+                    <li>Chapter 5: Software</li>
+                    <li>Chapter 6: Support Documentation and Services</li>
                   </ul>
                 </td>
               </tr>
@@ -420,8 +455,8 @@
             follows:
           </p>
           <ul>
-            <li>40 supported</li>
-            <li>12 partially supported</li>
+            <li>32 supported</li>
+            <li>20 partially supported</li>
             <li>0 not supported</li>
             <li>68 not applicable</li>
           </ul>
@@ -453,7 +488,7 @@
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -482,27 +517,20 @@
                       ><strong>Web</strong>:
                     </span>
                     <p>
-                      Drupal core has no outstanding user barriers. There are
-                      improvements in the
+                      There are minor barriers which may present themselves to
+                      users. There are improvements in the
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111"
                         >outstanding issues</a
                       >
-                      which relate to decorative and the password strength
-                      indicator.
+                      which relate to decorative images and the password
+                      strength indicator. Status messages should be clearly
+                      marked as decorative. Most of the issues are tied to the
+                      administration interface.
                     </p>
                     <p>
-                      All open WCAG 1.1.1 issues: 3232414, 2514218, 3272325,
-                      3230231, 3275397, 3087535, 3319601
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>
-                      Some non-textual content in the documentation does not
-                      provide a textual alternative.
+                      All open WCAG 1.1.1 issue(s): 2921627, 3083994, 3232414,
+                      2514218, 3272325, 3230231, 3275397, 3087535, 3319601
                     </p>
                   </li>
                   <li>
@@ -520,7 +548,7 @@
                     <p>
                       Alternative text is required for images by default.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111"
                         >Outstanding issues</a
                       >
                       relate to thumbnail images, management of decorative
@@ -581,12 +609,6 @@
                       Authors can satisfy 1.2.1 Audio-only and Video-only
                       (Prerecorded) by using text on the same page.
                     </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>This is not explicitly defined in the documentation.</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -717,15 +739,6 @@
                   </li>
                   <li>
                     <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>
-                      There is no documentation on how to properly convey
-                      pre-recorded audio descriptions.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
@@ -785,20 +798,21 @@
                     <p>
                       There are barriers in the
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag131"
                         >outstanding issues</a
                       >
                       ARIA landmarks and roles. There are also a number of
                       errors tied to forms (fieldsets, dates, radios &amp;
-                      checkboxes). There is also more work needed to provide
-                      better semantics for Voice Control and support for Windows
-                      High Contrast mode.
+                      checkboxes). More work is needed to provide better
+                      semantics for Voice Control and support for Windows High
+                      Contrast mode.
                     </p>
                     <p>
-                      All open WCAG 1.3.1 issues: 3081500, 2951317, 3098857,
-                      3347326, 3290899, 3171726, 2951714, 3144948, 3078334,
-                      2942404, 3190536, 3301868, 3171728, 3194669, 3200642,
-                      3206290, 3127469.
+                      All open WCAG 1.3.1 issue(s): 3182458, 3037726, 3037730,
+                      3037733, 3037725, 3037625, 2921627, 2937640, 3037446,
+                      3081500, 2951317, 3098857, 3347326, 3290899, 3171726,
+                      2951714, 3144948, 3078334, 2942404, 3190536, 3301868,
+                      3171728, 3194669, 3200642.
                     </p>
                   </li>
                   <li>
@@ -812,6 +826,10 @@
                       are also accessibility concerns with the vertical tabs and
                       dashboards available to users. Menu blocks are not getting
                       the correct ID in some instances.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag131"
+                        >Outstanding issues</a
+                      >.
                     </p>
                   </li>
                 </ul>
@@ -840,7 +858,7 @@
                     <span class="component-level-label"
                       ><strong>Electronic Documents</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Not Applicable</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -959,7 +977,7 @@
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -988,8 +1006,18 @@
                       ><strong>Web</strong>:
                     </span>
                     <p>
-                      Color is not used without text and often symbols to convey
-                      meaning.
+                      Color is generally not used without text and often symbols
+                      to convey meaning.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag141"
+                        >Outstanding issues</a
+                      >
+                      are mostly tied to authoring tools, but table drag
+                      components may also be exposed to an unauthorized user.
+                    </p>
+                    <p>
+                      All open WCAG 1.4.1 issue(s): 3097907, 3171726, 3059168,
+                      867830
                     </p>
                   </li>
                   <li>
@@ -1002,13 +1030,11 @@
                       tray, table drag, column severity and unpublished
                       articles.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag141"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag141"
                         >Outstanding issues</a
-                      >.
-                    </p>
-                    <p>
-                      All open WCAG 1.4.1 issues: 3097907, 3171726, 3281601,
-                      3059168, 867830.
+                      >
+                      also include the active toolbar tray, and the admin status
+                      report pages.
                     </p>
                   </li>
                 </ul>
@@ -1054,7 +1080,28 @@
                 </ul>
               </td>
               <td>
-                <ul class="component-level-count-4"></ul>
+                <ul class="component-level-count-4">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>
+                      The file module in Core lets authors upload audio and
+                      video content, and output and elements and does not
+                      support captions.
+                    </p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>
+                      The file module in Core lets authors upload audio and
+                      video content, and output and elements and does not
+                      support captions.
+                    </p>
+                  </li>
+                </ul>
               </td>
             </tr>
             <tr id="2.1.1">
@@ -1107,21 +1154,27 @@
                       with the keyboard and without specific timings for
                       individual keystrokes.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211"
                         >Outstanding issues</a
                       >
-                      with tooltips and the header menu.
+                      with tooltips and the header menu. There are also legacy
+                      issues with jQuery UI &amp; header menus. Items like
+                      datepickers can also be exposed to users.
                     </p>
-                    <p>All open WCAG 2.1.1 issues: 2933984, 3210434</p>
+                    <p>
+                      All open WCAG 2.1.1 issue(s): 3085811, 3229647, 3081515,
+                      2991686, 2911932, 3210434, 3038336, 2933984, 2852702
+                    </p>
                   </li>
                   <li>
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
-                      See remarks in Web section.
+                      Issues with the toolbar buttons, datepicker, contextual
+                      links, and tooltips. Also see remarks in Web section.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211"
                         >Outstanding issues</a
                       >.
                     </p>
@@ -1175,17 +1228,27 @@
                       ><strong>Web</strong>:
                     </span>
                     <p>
-                      Focus can be moved away from that component using only a
-                      keyboard interface.
+                      Users can move focus away from that component using only a
+                      keyboard interface. There is a known problem with the
+                      admin interface.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag212"
+                        >Outstanding issues</a
+                      >.
                     </p>
+                    <p>All open WCAG 2.1.2 issue(s): 2627788</p>
                   </li>
                   <li>
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
-                      Focus can be moved away from that component using only a
-                      keyboard interface.
+                      There is a known issue with focus states on text field
+                      AJAX calls.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag212"
+                        >Outstanding issues</a
+                      >.
                     </p>
                   </li>
                 </ul>
@@ -1466,12 +1529,6 @@
                   </li>
                   <li>
                     <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>Skip links are provided.</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>Skip links are provided.</p>
@@ -1496,7 +1553,7 @@
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -1514,7 +1571,7 @@
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                 </ul>
               </td>
@@ -1524,7 +1581,16 @@
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Pages are titled correctly.</p>
+                    <p>
+                      Pages are titled for users correctly. There is an
+                      outstanding issue for authors.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242"
+                        >Outstanding issues</a
+                      >
+                      are tied to pagination.
+                    </p>
+                    <p>All open WCAG 2.1.2 issue(s): 2514218, 2509716</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -1533,13 +1599,12 @@
                     <p>
                       Generally, pages are titled correctly.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242"
                         >Outstanding issues</a
                       >
                       with a regression in how fields are displayed in editing
                       content types.
                     </p>
-                    <p>All open WCAG 2.4.2 issues: 2514218</p>
                   </li>
                 </ul>
               </td>
@@ -1561,7 +1626,7 @@
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -1579,7 +1644,7 @@
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                 </ul>
               </td>
@@ -1590,17 +1655,17 @@
                       ><strong>Web</strong>:
                     </span>
                     <p>
-                      Focusable components receive focus in an order that
-                      preserves meaning and operability.
+                      Generally, focusable components receive focus in an order
+                      that preserves meaning and operability. Most of these
+                      issues are tied to the administration interface.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag243"
+                        >Outstanding issues</a
+                      >.
                     </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
                     <p>
-                      Focusable components receive focus in an order that
-                      preserves meaning and operability.
+                      All open WCAG 2.1.2 issue(s): 3019849, 3042107, 3047730,
+                      2973114, 2925295, 3273086
                     </p>
                   </li>
                   <li>
@@ -1608,8 +1673,15 @@
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
-                      Focusable components receive focus in an order that
-                      preserves meaning and operability.
+                      Generally, focusable components receive focus in an order
+                      that preserves meaning and operability.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag243"
+                        >Outstanding issues</a
+                      >. Some elements of the authoring interface to don't
+                      return the focus where an editor should expect it to.
+                      There are elements with table drag and Layout Builder
+                      which should be addressed.
                     </p>
                   </li>
                 </ul>
@@ -1632,7 +1704,7 @@
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -1664,6 +1736,14 @@
                       Careful attention has been paid to ensure that automated
                       "Read More" links are available in a way that is available
                       with contextual information for screen readers.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag244"
+                        >Outstanding issues</a
+                      >
+                      can be tied to user comments.
+                    </p>
+                    <p>
+                      All open WCAG 2.4.4 issue(s): 2922435, 3351638, 2852898
                     </p>
                   </li>
                   <li>
@@ -1673,13 +1753,12 @@
                     <p>
                       Generally very well-supported.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag244"
                         >Outstanding issues</a
                       >
                       with truncation of the path alias and duplicate links on
                       edit content page.
                     </p>
-                    <p>All open WCAG 2.4.2 issues: 3351638, 2852898</p>
                   </li>
                 </ul>
               </td>
@@ -1719,7 +1798,7 @@
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>Not Applicable</p>
+                    <p>Supports</p>
                   </li>
                 </ul>
               </td>
@@ -1729,7 +1808,7 @@
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>No known challenges with pointer gestures.</p>
+                    <p>Pointer gestures are generally very good.</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -1786,7 +1865,16 @@
                       ><strong>Web</strong>:
                     </span>
                     <p>
-                      No known problems for users with pointer cancellation.
+                      No known problems for users with pointer cancellation for
+                      users.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag252"
+                        >Outstanding issue(s)</a
+                      >.
+                    </p>
+                    <p>
+                      All open WCAG 2.5.2 issue(s): 2616184, 2968637, 2960840,
+                      2958654
                     </p>
                   </li>
                   <li>
@@ -1797,13 +1885,12 @@
                       The Drupal ajax framework uses 'mousedown' to capture the
                       click.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag252"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag252"
                         >Outstanding issue(s)</a
                       >
                       with truncation of the path alias and duplicate links on
                       edit content page.
                     </p>
-                    <p>All open WCAG 2.5.2 issue(s): 2616184</p>
                   </li>
                 </ul>
               </td>
@@ -1969,21 +2056,9 @@
                   </li>
                   <li>
                     <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>Page language is defined semantically on every page.</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>
-                      <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag311"
-                        >Outstanding issues</a
-                      >.
-                    </p>
-                    <p>All open WCAG 3.1.1 issue(s): 3081526</p>
+                    <p>Page language is defined semantically on every page.</p>
                   </li>
                 </ul>
               </td>
@@ -2032,15 +2107,6 @@
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
-                    </span>
-                    <p>
-                      Change in the focus state does not initiate a change of
-                      context for the user.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
                     </span>
                     <p>
                       Change in the focus state does not initiate a change of
@@ -2111,15 +2177,6 @@
                   </li>
                   <li>
                     <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>
-                      Engaging with the interactive sites does not unexpectedly
-                      take control from the users.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
@@ -2179,15 +2236,15 @@
                       The Inline Form Error module needs to be enabled site-wide
                       on installation.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag311"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag331"
                         >Outstanding issues</a
                       >. Most of these issues are also authoring interface, but
                       there are problems with HTML5 validation, child groupings,
                       required errors, and file uploading.
                     </p>
                     <p>
-                      All open WCAG 3.3.1 issues: 3059955, 1797438, 2848507,
-                      2563173, 3087305, 2455933, 3087402, 2847425, 2089703
+                      All open WCAG 3.3.1 issue(s): 2848307, 2560467, 2876321,
+                      3279596, 3087385, 3059955, 1797438, 2848507, 2563173
                     </p>
                   </li>
                   <li>
@@ -2197,7 +2254,7 @@
                     <p>
                       See the Web section as most of these
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag311"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag331"
                         >outstanding issues</a
                       >
                       are also likely on the user side.
@@ -2254,13 +2311,17 @@
                     <p>
                       Default forms all include labels.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332"
                         >Outstanding issues</a
                       >
                       include a lack of 'aria-describedby' and grouped fields
-                      missing labels.
+                      missing labels. There are some exceptions like Views
+                      search filter label isn't associated with the input.
                     </p>
-                    <p>All open WCAG 3.3.2 issues: 2998857, 2608212</p>
+                    <p>
+                      All open WCAG 3.3.2 issue(s): 2608180, 2942037, 3037446,
+                      2998857, 2608212
+                    </p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2271,9 +2332,10 @@
                       labels, but these are odd exceptions. See the Web section
                       for details.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332"
                         >Outstanding issues</a
-                      >.
+                      >. There are known issues with the Admin list filter and
+                      grouped publishing status messages.
                     </p>
                   </li>
                 </ul>
@@ -2324,16 +2386,12 @@
                     <p>
                       There are no HTML5 errors or warnings that are known to
                       impact assistive technology users.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag411"
+                        >Outstanding issues</a
+                      >.
                     </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>
-                      There are no HTML5 errors or warnings that are known to
-                      impact assistive technology users.
-                    </p>
+                    <p>All open WCAG 4.1.1 issue(s): 3174459</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2343,11 +2401,11 @@
                       Generally parsing is very well-supported, but there are a
                       few places where this needs to be improved.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag411"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag411"
                         >Outstanding issues</a
-                      >.
+                      >. There is an error identified with fields in articles
+                      that has not been independently validated.
                     </p>
-                    <p>All open WCAG 4.1.1 issue(s): 3174459</p>
                   </li>
                 </ul>
               </td>
@@ -2369,7 +2427,7 @@
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2397,13 +2455,18 @@
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Public pages support this criterion.</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>Public pages support this criterion.</p>
+                    <p>
+                      Public pages generally support this criterion.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag412"
+                        >Outstanding issues</a
+                      >. There are issues when Views List is filtered.
+                    </p>
+                    <p>
+                      All open WCAG 4.1.2 issue(s): 3050559, 2805499, 2913378,
+                      2805227, 1096124, 2047089, 3272316, 2942232, 3087313,
+                      2719453
+                    </p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2413,14 +2476,10 @@
                       This is generally well-supported, but there are places
                       where it has been overlooked.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag412"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag412"
                         >Outstanding issues</a
                       >. There are semantics missing for aria elements in the
-                      block, forms, and contextual modules.
-                    </p>
-                    <p>
-                      All open WCAG 4.1.2 issues: 3083181, 2852724, 3218877,
-                      3028780, 1852090, 3085545
+                      block, forms, media, bulk actions and contextual modules.
                     </p>
                   </li>
                 </ul>
@@ -2450,9 +2509,9 @@
           </p>
           <ul>
             <li>24 supported</li>
-            <li>11 partially supported</li>
-            <li>3 not supported</li>
-            <li>32 not applicable</li>
+            <li>13 partially supported</li>
+            <li>2 not supported</li>
+            <li>40 not applicable</li>
           </ul>
         </div>
 
@@ -2512,6 +2571,12 @@
                     </span>
                     <p>This is not a feature supported in Drupal Core.</p>
                   </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>This is not a feature supported in Drupal Core.</p>
+                  </li>
                 </ul>
               </td>
             </tr>
@@ -2540,7 +2605,7 @@
                     <span class="component-level-label"
                       ><strong>Electronic Documents</strong>:
                     </span>
-                    <p>Does Not Support</p>
+                    <p>Not Applicable</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2569,15 +2634,6 @@
                   </li>
                   <li>
                     <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>
-                      There is no documentation on how to properly convey
-                      pre-recorded audio descriptions.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
@@ -2601,10 +2657,48 @@
                 </a>
               </td>
               <td>
-                <ul class="component-level-count-0"></ul>
+                <ul class="component-level-count-4">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>Supports</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Electronic Documents</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Software</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>Supports</p>
+                  </li>
+                </ul>
               </td>
               <td>
-                <ul class="component-level-count-0"></ul>
+                <ul class="component-level-count-4">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>No known problems with orientation.</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>No known problems with orientation.</p>
+                  </li>
+                </ul>
               </td>
             </tr>
             <tr id="1.3.5">
@@ -2619,10 +2713,48 @@
                 </a>
               </td>
               <td>
-                <ul class="component-level-count-0"></ul>
+                <ul class="component-level-count-4">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>Supports</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Electronic Documents</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Software</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>Supports</p>
+                  </li>
+                </ul>
               </td>
               <td>
-                <ul class="component-level-count-0"></ul>
+                <ul class="component-level-count-4">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>No known problems with input purpose.</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>No known problems with input purpose.</p>
+                  </li>
+                </ul>
               </td>
             </tr>
             <tr id="1.4.3">
@@ -2676,20 +2808,14 @@
                       form labels, disabled form elements, and some dialogs
                       require additional contrast to meet 1.4.3 requirements.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143"
                         >Outstanding issues</a
                       >.
                     </p>
                     <p>
-                      All open WCAG 1.4.3 issue(s): 3266299, 3040673, 3231744,
-                      3200635, 2756483, 2725539, 3076153
+                      All open WCAG 1.4.3 issue(s): 3271652, 3318394, 3266299,
+                      3040673, 3231744, 3200635, 2756483, 2725539, 3076153
                     </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>The docs have sufficient contrast.</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2699,7 +2825,7 @@
                       Generally meets requirements. Form elements described in
                       the web section affect both user and author interfaces.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143"
                         >Outstanding issues</a
                       >.
                     </p>
@@ -2756,17 +2882,11 @@
                       Generally support with a minor exception with focus
                       outlines.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144"
                         >Outstanding issues</a
                       >.
                     </p>
-                    <p>All WCAG 1.4.4 issues: 3068698, 3238618</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>The docs are accessible up to 200%.</p>
+                    <p>All WCAG 1.4.4 issue(s): 3068698, 3238618, 2384203</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2776,7 +2896,7 @@
                       Generally support with some minor exception with limited
                       horizontal space.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144"
                         >Outstanding issues</a
                       >.
                     </p>
@@ -2890,13 +3010,13 @@
                       Generally meets. Some issues with long words, responsive
                       tables, resizing menus, and wide screen layout.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410"
                         >Outstanding issues</a
                       >.
                     </p>
                     <p>
-                      All open WCAG 1.4.10 issues: 3159896, 3177475, 2280035,
-                      3191806, 2574721, 3164587.
+                      All open WCAG 1.4.10 issue(s): 2313471, 3159896, 3177475,
+                      2280035, 3191806, 2574721, 3164587
                     </p>
                   </li>
                   <li>
@@ -2909,7 +3029,7 @@
                       some minor exception with the action links on the modules
                       page.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410"
                         >Outstanding issues</a
                       >.
                     </p>
@@ -2966,13 +3086,14 @@
                       Generally meets. There are still some images that need to
                       have their contrast increased.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411"
                         >Outstanding issues</a
                       >.
                     </p>
                     <p>
-                      All open WCAG 1.4.11 issues: 3097907, 2910102, 3171726,
-                      3272266, 3037742
+                      All open WCAG 1.4.11 issue(s): 3273806, 3270130, 3269420,
+                      3269342, 3277262, 2990766, 3097907, 2910102, 3171726,
+                      3272266
                     </p>
                   </li>
                   <li>
@@ -2986,7 +3107,7 @@
                     </p>
                     <p>
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411"
                         >Outstanding issues</a
                       >.
                     </p>
@@ -3037,17 +3158,29 @@
                 <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>
+                      All known related issues are tied to the admin interface.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1412"
+                        >Outstanding issues</a
+                      >.
+                    </p>
+                    <p>All open WCAG 1.4.12 issue(s): 2919837</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
                       Generally supports. There is a known issue with off-canvas
                       dialogs.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1412"
                         >Outstanding issues</a
                       >.
                     </p>
-                    <p>All open WCAG 1.4.12 issues: 2919837</p>
                   </li>
                 </ul>
               </td>
@@ -3160,15 +3293,6 @@
                   </li>
                   <li>
                     <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>
-                      There is more than one way to locate a Web page within the
-                      CMS.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
@@ -3214,7 +3338,7 @@
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                 </ul>
               </td>
@@ -3224,13 +3348,32 @@
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Generally there is very good support.</p>
+                    <p>
+                      Generally there is very good support.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag246"
+                        >Outstanding issues</a
+                      >
+                      are for the admin interface.
+                    </p>
+                    <p>
+                      All open WCAG 2.4.6 issue(s): 3232222, 3277785, 2614950,
+                      3333401, 3293673
+                    </p>
                   </li>
                   <li>
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>Generally good.</p>
+                    <p>
+                      Generally good.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag246"
+                        >Outstanding issues</a
+                      >
+                      are tied to header for the pager template can be outside
+                      the document hierarchy order.
+                    </p>
                   </li>
                 </ul>
               </td>
@@ -3281,7 +3424,16 @@
                       ><strong>Web</strong>:
                     </span>
                     <p>
-                      Focus elements are well established for the front-end.
+                      Generally there is very good support.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag247"
+                        >Outstanding issues</a
+                      >.
+                    </p>
+                    <p>
+                      All open WCAG 2.4.7 issue(s): 2990588, 2822778, 3273054,
+                      3200584, 3191727, 3270230, 3091534, 3335411, 3302103,
+                      3273099
                     </p>
                   </li>
                   <li>
@@ -3289,15 +3441,15 @@
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
-                      Generally supports. There is a known
+                      Generally supports. There is an
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag247"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag247"
                         >outstanding issues</a
                       >. A block can be added with layout builder that stops
                       authors from escaping focus. The image style page also has
-                      a hidden focus element.
+                      a hidden focus element. There are issues with modal popups
+                      in Views and with Toolbar focus styles.
                     </p>
-                    <p>All open WCAG 2.47 issues: 3302103, 3273099</p>
                   </li>
                 </ul>
               </td>
@@ -3349,9 +3501,18 @@
                     </span>
                     <p>
                       Multilingual sites have language switchers with proper
-                      semantics. Unfotunately support is lacking for
-                      multi-lingual search 2992894 as well as both the
-                      Filesystem 3163915 &amp; Views components 2496223.
+                      semantics. Unfortunately support is lacking for
+                      multilingual search as well as both the Filesystem and
+                      Views components.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag312"
+                        >Outstanding issues</a
+                      >.
+                    </p>
+                    <p>
+                      All open WCAG 3.1.2 issue(s): 3300835, 3361370, 3361375,
+                      3362791, 2036277, 3300836, 3042984, 82751, 3163915,
+                      3049122
                     </p>
                   </li>
                   <li>
@@ -3363,6 +3524,11 @@
                       accessibility. To support the Language of Parts for
                       authors, a button can be added to simplify the process of
                       adding language specific phrases.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag312"
+                        >Outstanding issues</a
+                      >. There are untranslatable fields in parts of the
+                      administration interface that are known.
                     </p>
                   </li>
                 </ul>
@@ -3380,7 +3546,7 @@
                 </a>
               </td>
               <td>
-                <ul class="component-level-count-3">
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3391,18 +3557,24 @@
                     <span class="component-level-label"
                       ><strong>Electronic Documents</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Not Applicable</p>
                   </li>
                   <li>
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Software</strong>:
+                    </span>
+                    <p>Not Applicable</p>
                   </li>
                 </ul>
               </td>
               <td>
-                <ul class="component-level-count-3">
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3410,15 +3582,14 @@
                     <p>
                       Drupal's menu structure allows for consistent navigation
                       across the site.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag323"
+                        >Outstanding issues</a
+                      >. There are some minor issues with mobile in Olivero.
                     </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
                     <p>
-                      Drupal's menu structure allows for consistent navigation
-                      across the site.
+                      All open WCAG 3.2.3 issue(s): 3129257, 3209129, 3350947,
+                      3084554, 2895388
                     </p>
                   </li>
                   <li>
@@ -3428,6 +3599,11 @@
                     <p>
                       Drupal's menu structure allows for consistent navigation
                       across the site.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag323"
+                        >Outstanding issues</a
+                      >. There are issues with scrolling with layout builder and
+                      with the Modules Uninstall filter.
                     </p>
                   </li>
                 </ul>
@@ -3456,7 +3632,7 @@
                     <span class="component-level-label"
                       ><strong>Electronic Documents</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Not Applicable</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -3471,15 +3647,6 @@
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
-                    </span>
-                    <p>
-                      Components in Drupal that have the same functionality are
-                      identified consistently.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
                     </span>
                     <p>
                       Components in Drupal that have the same functionality are
@@ -3611,12 +3778,6 @@
                   </li>
                   <li>
                     <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>Documentation could be improved.</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
@@ -3672,15 +3833,305 @@
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>No known problems with status messages.</p>
+                    <p>
+                      No known problems with status messages.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag413"
+                        >Outstanding issues</a
+                      >.
+                    </p>
+                    <p>
+                      All open WCAG 4.1.3 issue(s): 2973116, 2893663, 3035435,
+                      3159933, 2973140
+                    </p>
                   </li>
                   <li>
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>No known problems with status messages.</p>
+                    <p>
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag413"
+                        >Outstanding issues</a
+                      >
+                      are known after enabling/disabling a View, with the
+                      dropdown buttons, and with progress messages.
+                    </p>
                   </li>
                 </ul>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3 id="success_criteria_level_aaa">
+          Table 3: Success Criteria, Level AAA
+          <a href="#success_criteria_level_aaa" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
+                <path
+                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
+        </h3>
+
+        <div
+          id="success_criteria_level_aaa-notes"
+          class="chapter-notes-section"
+        >
+          Notes:
+          <p>
+            Where possible the Drupal community strives to exceed AA compliance.
+          </p>
+        </div>
+
+        <h2 id="508">
+          Revised Section 508 Report
+          <a href="#508" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
+                <path
+                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
+        </h2>
+
+        <h3 id="functional_performance_criteria">
+          Chapter 3: Functional Performance Criteria (FPC)
+          <a href="#functional_performance_criteria" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
+                <path
+                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
+        </h3>
+
+        <div
+          id="functional_performance_criteria-notes"
+          class="chapter-notes-section"
+        >
+          Notes:
+          <p>Not applicable.</p>
+        </div>
+
+        <h3 id="hardware">
+          Chapter 4: Hardware
+          <a href="#hardware" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
+                <path
+                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
+        </h3>
+
+        <div id="hardware-notes" class="chapter-notes-section">
+          Notes:
+          <p>
+            Drupal is a web application. Hardware accessibility criteria is not
+            applicable.
+          </p>
+        </div>
+
+        <h3 id="software">
+          Chapter 5: Software
+          <a href="#software" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
+                <path
+                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
+        </h3>
+
+        <div id="software-notes" class="chapter-notes-section">
+          Notes:
+          <p>
+            Drupal is a web application. Software accessibility criteria is not
+            applicable.
+          </p>
+        </div>
+
+        <h3 id="support_documentation_and_services">
+          Chapter 6: Support Documentation and Services
+          <a href="#support_documentation_and_services" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
+                <path
+                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
+        </h3>
+
+        <div
+          id="support_documentation_and_services-notes"
+          class="chapter-notes-section"
+        >
+          Notes:
+          <p>
+            Drupal is a web application and all support documentation is
+            delivered through the web. Additional documentation and services are
+            not available.
+          </p>
+        </div>
+
+        <div id="support_documentation_and_services-summary">
+          <p>
+            Conformance to the 5 criteria listed below is distributed as
+            follows:
+          </p>
+          <ul>
+            <li>0 supported</li>
+            <li>0 partially supported</li>
+            <li>0 not supported</li>
+            <li>4 not applicable</li>
+          </ul>
+        </div>
+
+        <table class="usa-table">
+          <thead>
+            <tr>
+              <th>Criteria</th>
+              <th>Conformance Level</th>
+              <th>Remarks and Explanations</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr id="602.2">
+              <td>
+                <a
+                  href="https://www.access-board.gov/ict/#602.2"
+                  target="_blank"
+                >
+                  602.2 Accessibility and Compatibility Features<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
+                  >
+                </a>
+              </td>
+              <td>
+                <ul class="component-level-count-1">
+                  <li>
+                    <span class="component-level-label"></span>
+                    <p>Not Applicable</p>
+                  </li>
+                </ul>
+              </td>
+              <td>
+                <ul class="component-level-count-1"></ul>
+              </td>
+            </tr>
+            <tr id="602.4">
+              <td>
+                <a
+                  href="https://www.access-board.gov/ict/#602.4"
+                  target="_blank"
+                >
+                  602.4 Alternate Formats for Non-Electronic Support
+                  Documentation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
+              </td>
+              <td>
+                <ul class="component-level-count-1">
+                  <li>
+                    <span class="component-level-label"></span>
+                    <p>Not Applicable</p>
+                  </li>
+                </ul>
+              </td>
+              <td>
+                <ul class="component-level-count-1"></ul>
+              </td>
+            </tr>
+            <tr id="603.2">
+              <td>
+                <a
+                  href="https://www.access-board.gov/ict/#603.2"
+                  target="_blank"
+                >
+                  603.2 Information on Accessibility and Compatibility
+                  Features<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
+              </td>
+              <td>
+                <ul class="component-level-count-1">
+                  <li>
+                    <span class="component-level-label"></span>
+                    <p>Not Applicable</p>
+                  </li>
+                </ul>
+              </td>
+              <td>
+                <ul class="component-level-count-1"></ul>
+              </td>
+            </tr>
+            <tr id="603.3">
+              <td>
+                <a
+                  href="https://www.access-board.gov/ict/#603.3"
+                  target="_blank"
+                >
+                  603.3 Accommodation of Communication Needs<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
+                  >
+                </a>
+              </td>
+              <td>
+                <ul class="component-level-count-1">
+                  <li>
+                    <span class="component-level-label"></span>
+                    <p>Not Applicable</p>
+                  </li>
+                </ul>
+              </td>
+              <td>
+                <ul class="component-level-count-1"></ul>
+              </td>
+            </tr>
+            <tr id="602.3">
+              <td>
+                <a
+                  href="https://www.access-board.gov/ict/#602.3"
+                  target="_blank"
+                >
+                  602.3 Electronic Support Documentation<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
+                  >
+                </a>
+              </td>
+              <td>
+                <ul class="component-level-count-0"></ul>
+              </td>
+              <td>
+                <ul class="component-level-count-0"></ul>
               </td>
             </tr>
           </tbody>
@@ -3721,8 +4172,8 @@
           </a>
         </h2>
         <a
-          href="https://github.com/CivicActions/openacr/blob/main/openacr/drupal-10-15.yaml"
-          >https://github.com/CivicActions/openacr/blob/main/openacr/drupal-10-15.yaml</a
+          href="https://github.com/CivicActions/openacr/blob/main/openacr/drupal-10-16.yaml"
+          >https://github.com/CivicActions/openacr/blob/main/openacr/drupal-10-16.yaml</a
         >
         <h2 id="feedback">
           Feedback
@@ -3740,6 +4191,23 @@
         <a href="https://www.drupal.org/project/issues/drupal"
           >https://www.drupal.org/project/issues/drupal</a
         >
+
+        <h2 id="related-openacrs">
+          Related OpenACRs
+          <a href="#related-openacrs" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
+                <path
+                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
+        </h2>
+        <ul>
+          <li><a href=""> (secondary)</a></li>
+        </ul>
       </div>
     </main>
     <footer class="usa-footer usa-footer usa-footer--slim">

--- a/openacr/drupal-10-16-simple.html
+++ b/openacr/drupal-10-16-simple.html
@@ -109,6 +109,7 @@
 
       table {
         border-collapse: collapse;
+        margin: 10px 0;
       }
       th,
       td {
@@ -124,9 +125,7 @@
           Report
         </h1>
 
-        <div class="catalog-section">
-          Based on VPAT® 2.4 WCAG 2.1 and Revised Section 508 Edition
-        </div>
+        <div class="catalog-section">Based on VPAT® 2.4</div>
 
         <div class="product-section">
           <h2 id="name-of-product-version">
@@ -342,24 +341,6 @@
                   </ul>
                 </td>
               </tr>
-              <tr>
-                <td>
-                  <a href="https://www.access-board.gov/ict/" target="_blank"
-                    >Revised Section 508 standards published January 18, 2017
-                    and corrected January 22, 2018<span class="usa-sr-only">
-                      (opens in a new window or tab)</span
-                    ></a
-                  >
-                </td>
-                <td>
-                  <ul>
-                    <li>Chapter 3: Functional Performance Criteria (FPC)</li>
-                    <li>Chapter 4: Hardware</li>
-                    <li>Chapter 5: Software</li>
-                    <li>Chapter 6: Support Documentation and Services</li>
-                  </ul>
-                </td>
-              </tr>
             </tbody>
           </table>
         </div>
@@ -450,16 +431,49 @@
         </div>
 
         <div id="success_criteria_level_a-summary">
-          <p>
-            Conformance to the 30 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>32 supported</li>
-            <li>20 partially supported</li>
-            <li>0 not supported</li>
-            <li>68 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 30 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>16</td>
+              <td>0</td>
+              <td>0</td>
+              <td>16</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>10</td>
+              <td>0</td>
+              <td>0</td>
+              <td>10</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>4</td>
+              <td>30</td>
+              <td>30</td>
+              <td>4</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2503,16 +2517,49 @@
         </h3>
 
         <div id="success_criteria_level_aa-summary">
-          <p>
-            Conformance to the 20 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>24 supported</li>
-            <li>13 partially supported</li>
-            <li>2 not supported</li>
-            <li>40 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 20 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>12</td>
+              <td>1</td>
+              <td>0</td>
+              <td>11</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>6</td>
+              <td>0</td>
+              <td>0</td>
+              <td>7</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>1</td>
+              <td>0</td>
+              <td>0</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>1</td>
+              <td>19</td>
+              <td>19</td>
+              <td>1</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -3887,255 +3934,6 @@
             Where possible the Drupal community strives to exceed AA compliance.
           </p>
         </div>
-
-        <h2 id="508">
-          Revised Section 508 Report
-          <a href="#508" class="header-anchor">
-            <span class="anchor-icon" aria-hidden="true">
-              <svg focusable="false" aria-hidden="true" class="icon-link">
-                <path
-                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                />
-              </svg>
-            </span>
-            <span class="visuallyhidden">Anchor link</span>
-          </a>
-        </h2>
-
-        <h3 id="functional_performance_criteria">
-          Chapter 3: Functional Performance Criteria (FPC)
-          <a href="#functional_performance_criteria" class="header-anchor">
-            <span class="anchor-icon" aria-hidden="true">
-              <svg focusable="false" aria-hidden="true" class="icon-link">
-                <path
-                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                />
-              </svg>
-            </span>
-            <span class="visuallyhidden">Anchor link</span>
-          </a>
-        </h3>
-
-        <div
-          id="functional_performance_criteria-notes"
-          class="chapter-notes-section"
-        >
-          Notes:
-          <p>Not applicable.</p>
-        </div>
-
-        <h3 id="hardware">
-          Chapter 4: Hardware
-          <a href="#hardware" class="header-anchor">
-            <span class="anchor-icon" aria-hidden="true">
-              <svg focusable="false" aria-hidden="true" class="icon-link">
-                <path
-                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                />
-              </svg>
-            </span>
-            <span class="visuallyhidden">Anchor link</span>
-          </a>
-        </h3>
-
-        <div id="hardware-notes" class="chapter-notes-section">
-          Notes:
-          <p>
-            Drupal is a web application. Hardware accessibility criteria is not
-            applicable.
-          </p>
-        </div>
-
-        <h3 id="software">
-          Chapter 5: Software
-          <a href="#software" class="header-anchor">
-            <span class="anchor-icon" aria-hidden="true">
-              <svg focusable="false" aria-hidden="true" class="icon-link">
-                <path
-                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                />
-              </svg>
-            </span>
-            <span class="visuallyhidden">Anchor link</span>
-          </a>
-        </h3>
-
-        <div id="software-notes" class="chapter-notes-section">
-          Notes:
-          <p>
-            Drupal is a web application. Software accessibility criteria is not
-            applicable.
-          </p>
-        </div>
-
-        <h3 id="support_documentation_and_services">
-          Chapter 6: Support Documentation and Services
-          <a href="#support_documentation_and_services" class="header-anchor">
-            <span class="anchor-icon" aria-hidden="true">
-              <svg focusable="false" aria-hidden="true" class="icon-link">
-                <path
-                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                />
-              </svg>
-            </span>
-            <span class="visuallyhidden">Anchor link</span>
-          </a>
-        </h3>
-
-        <div
-          id="support_documentation_and_services-notes"
-          class="chapter-notes-section"
-        >
-          Notes:
-          <p>
-            Drupal is a web application and all support documentation is
-            delivered through the web. Additional documentation and services are
-            not available.
-          </p>
-        </div>
-
-        <div id="support_documentation_and_services-summary">
-          <p>
-            Conformance to the 5 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>0 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>4 not applicable</li>
-          </ul>
-        </div>
-
-        <table class="usa-table">
-          <thead>
-            <tr>
-              <th>Criteria</th>
-              <th>Conformance Level</th>
-              <th>Remarks and Explanations</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr id="602.2">
-              <td>
-                <a
-                  href="https://www.access-board.gov/ict/#602.2"
-                  target="_blank"
-                >
-                  602.2 Accessibility and Compatibility Features<span
-                    class="usa-sr-only"
-                  >
-                    (opens in a new window or tab)</span
-                  >
-                </a>
-              </td>
-              <td>
-                <ul class="component-level-count-1">
-                  <li>
-                    <span class="component-level-label"></span>
-                    <p>Not Applicable</p>
-                  </li>
-                </ul>
-              </td>
-              <td>
-                <ul class="component-level-count-1"></ul>
-              </td>
-            </tr>
-            <tr id="602.4">
-              <td>
-                <a
-                  href="https://www.access-board.gov/ict/#602.4"
-                  target="_blank"
-                >
-                  602.4 Alternate Formats for Non-Electronic Support
-                  Documentation<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
-              </td>
-              <td>
-                <ul class="component-level-count-1">
-                  <li>
-                    <span class="component-level-label"></span>
-                    <p>Not Applicable</p>
-                  </li>
-                </ul>
-              </td>
-              <td>
-                <ul class="component-level-count-1"></ul>
-              </td>
-            </tr>
-            <tr id="603.2">
-              <td>
-                <a
-                  href="https://www.access-board.gov/ict/#603.2"
-                  target="_blank"
-                >
-                  603.2 Information on Accessibility and Compatibility
-                  Features<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
-              </td>
-              <td>
-                <ul class="component-level-count-1">
-                  <li>
-                    <span class="component-level-label"></span>
-                    <p>Not Applicable</p>
-                  </li>
-                </ul>
-              </td>
-              <td>
-                <ul class="component-level-count-1"></ul>
-              </td>
-            </tr>
-            <tr id="603.3">
-              <td>
-                <a
-                  href="https://www.access-board.gov/ict/#603.3"
-                  target="_blank"
-                >
-                  603.3 Accommodation of Communication Needs<span
-                    class="usa-sr-only"
-                  >
-                    (opens in a new window or tab)</span
-                  >
-                </a>
-              </td>
-              <td>
-                <ul class="component-level-count-1">
-                  <li>
-                    <span class="component-level-label"></span>
-                    <p>Not Applicable</p>
-                  </li>
-                </ul>
-              </td>
-              <td>
-                <ul class="component-level-count-1"></ul>
-              </td>
-            </tr>
-            <tr id="602.3">
-              <td>
-                <a
-                  href="https://www.access-board.gov/ict/#602.3"
-                  target="_blank"
-                >
-                  602.3 Electronic Support Documentation<span
-                    class="usa-sr-only"
-                  >
-                    (opens in a new window or tab)</span
-                  >
-                </a>
-              </td>
-              <td>
-                <ul class="component-level-count-0"></ul>
-              </td>
-              <td>
-                <ul class="component-level-count-0"></ul>
-              </td>
-            </tr>
-          </tbody>
-        </table>
 
         <h2 id="legal-disclaimer">
           Legal Disclaimer

--- a/openacr/drupal-10-16.html
+++ b/openacr/drupal-10-16.html
@@ -333,16 +333,49 @@
         </div>
 
         <div id="success_criteria_level_a-summary">
-          <p>
-            Conformance to the 30 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>32 supported</li>
-            <li>20 partially supported</li>
-            <li>0 not supported</li>
-            <li>68 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 30 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>16</td>
+              <td>0</td>
+              <td>0</td>
+              <td>16</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>10</td>
+              <td>0</td>
+              <td>0</td>
+              <td>10</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>4</td>
+              <td>30</td>
+              <td>30</td>
+              <td>4</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2386,16 +2419,49 @@
         </h3>
 
         <div id="success_criteria_level_aa-summary">
-          <p>
-            Conformance to the 20 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>24 supported</li>
-            <li>13 partially supported</li>
-            <li>2 not supported</li>
-            <li>40 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 20 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>12</td>
+              <td>1</td>
+              <td>0</td>
+              <td>11</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>6</td>
+              <td>0</td>
+              <td>0</td>
+              <td>7</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>1</td>
+              <td>0</td>
+              <td>0</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>1</td>
+              <td>19</td>
+              <td>19</td>
+              <td>1</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">

--- a/openacr/drupal-10-16.html
+++ b/openacr/drupal-10-16.html
@@ -1,85 +1,171 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <title>Drupal</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Drupal</title>
-    <script
-      type="text/javascript"
-      charset="utf8"
-      src="uswds/js/uswds-init.min.js"
-    ></script>
-    <link rel="stylesheet" href="uswds/css/uswds.min.css" />
-    <link rel="stylesheet" href="openacr.css" />
-    <link rel="stylesheet" href="custom.css" />
   </head>
-  <body>
-    <script
-      type="text/javascript"
-      charset="utf8"
-      src="uswds/js/uswds.min.js"
-    ></script>
+  <body id="openACR">
+    <style>
+      body#openACR {
+        padding-left: 35px;
+      }
+      h2,
+      h3 {
+        position: relative;
+      }
+      h2 a.header-anchor,
+      h3 a.header-anchor {
+        position: absolute;
+        left: -2rem;
+      }
+      h2 a.header-anchor:hover svg,
+      h2 a.header-anchor:focus svg,
+      h2 a.header-anchor:focus-within svg,
+      h3 a.header-anchor:hover svg,
+      h3 a.header-anchor:focus svg,
+      h3 a.header-anchor:focus-within svg {
+        fill: #0000ee;
+        opacity: 1;
+      }
+      h2 a.header-anchor svg,
+      h3 a.header-anchor svg {
+        width: 28px;
+        height: 28px;
+        opacity: 0.3;
+      }
+      @media all and (max-width: 63.99em) {
+        h2 a.header-anchor,
+        h3 a.header-anchor {
+          position: relative;
+          opacity: 1;
+          left: 0;
+          vertical-align: top;
+        }
+      }
+      a.header-anchor {
+        opacity: 0.4;
+        font-size: small;
+        text-decoration: none;
+        position: relative;
+        /* left: 20px; */
+        -webkit-transition: opacity 1s, font-size 1s;
+        -moz-transition: opacity 1s, font-size 1s;
+        -o-transition: opacity 1s, font-size 1s;
+        transition: opacity 1s, font-size 1s;
+      }
+      a.header-anchor:focus,
+      a.header-anchor:hover {
+        text-decoration: underline;
+        font-size: large;
+        opacity: 1;
+      }
+      .visuallyhidden {
+        border: 0;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+        white-space: nowrap;
+        &.focusable {
+          &:active,
+          &:focus {
+            clip: auto;
+            clip-path: none;
+            height: auto;
+            margin: 0;
+            overflow: visible;
+            position: static;
+            width: auto;
+            white-space: inherit;
+          }
+        }
+      }
+      .applicable-standards-guidelines-table th:nth-child(1) {
+        width: 40%;
+      }
+      .applicable-standards-guidelines-table th:nth-child(2) {
+        width: 60%;
+      }
+      /* If only one level then hide the label. */
+      .component-level-count-1 .component-level-label {
+        display: none;
+      }
+    </style>
     <main>
       <div class="grid-container">
-        <h1>
+        <h1 class="svelte-1nee40z">
           <span class="evaluation-title">Drupal</span> Accessibility Conformance
           Report
         </h1>
-
         <div class="catalog-section">Based on VPAT® 2.4</div>
-
         <div class="product-section">
-          <h2 id="name-of-product-version">
+          <h2 id="name-of-product-version-download" class="svelte-1y7sq6j">
             Name of Product/Version
-            <a href="#name-of-product-version" class="header-anchor">
-              <span class="anchor-icon" aria-hidden="true">
-                <svg focusable="false" aria-hidden="true" class="icon-link">
+            <a
+              href="#name-of-product-version-download"
+              class="header-anchor svelte-1y7sq6j"
+              ><span class="anchor-icon" aria-hidden="true"
+                ><svg
+                  focusable="false"
+                  aria-hidden="true"
+                  class="icon-link svelte-1y7sq6j"
+                >
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  />
-                </svg>
-              </span>
-              <span class="visuallyhidden">Anchor link</span>
-            </a>
+                  ></path></svg
+              ></span>
+              <span class="visuallyhidden">Anchor link</span></a
+            >
           </h2>
           Drupal 10
         </div>
-
         <div class="report-dates-ver-section">
-          <h2 id="report-date">
+          <h2 id="report-date-download" class="svelte-1y7sq6j">
             Report Dates and Version
-            <a href="#report-date" class="header-anchor">
-              <span class="anchor-icon" aria-hidden="true">
-                <svg focusable="false" aria-hidden="true" class="icon-link">
+            <a href="#report-date-download" class="header-anchor svelte-1y7sq6j"
+              ><span class="anchor-icon" aria-hidden="true"
+                ><svg
+                  focusable="false"
+                  aria-hidden="true"
+                  class="icon-link svelte-1y7sq6j"
+                >
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  />
-                </svg>
-              </span>
-              <span class="visuallyhidden">Anchor link</span>
-            </a>
+                  ></path></svg
+              ></span>
+              <span class="visuallyhidden">Anchor link</span></a
+            >
           </h2>
           <ul>
             <li>Report Date: 2023-05-12</li>
-            <li>Last Modified Date: 2023-05-16</li>
-            <li>Version: drupal-10-15</li>
+            <li>Last Modified Date: 2023-06-19</li>
+            <li>Version: drupal-10-16</li>
           </ul>
         </div>
-
         <div class="description-section">
-          <h2 id="product-description">
+          <h2 id="product-description-download" class="svelte-1y7sq6j">
             Product Description
-            <a href="#product-description" class="header-anchor">
-              <span class="anchor-icon" aria-hidden="true">
-                <svg focusable="false" aria-hidden="true" class="icon-link">
+            <a
+              href="#product-description-download"
+              class="header-anchor svelte-1y7sq6j"
+              ><span class="anchor-icon" aria-hidden="true"
+                ><svg
+                  focusable="false"
+                  aria-hidden="true"
+                  class="icon-link svelte-1y7sq6j"
+                >
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  />
-                </svg>
-              </span>
-              <span class="visuallyhidden">Anchor link</span>
-            </a>
+                  ></path></svg
+              ></span>
+              <span class="visuallyhidden">Anchor link</span></a
+            >
           </h2>
           <p>
             Drupal is an open source content management platform supporting a
@@ -87,34 +173,41 @@
             community-driven websites.
           </p>
         </div>
-
         <div id="contact-section">
-          <h2 id="contact-information">
+          <h2 id="contact-information-download" class="svelte-1y7sq6j">
             Contact Information
-            <a href="#contact-information" class="header-anchor">
-              <span class="anchor-icon" aria-hidden="true">
-                <svg focusable="false" aria-hidden="true" class="icon-link">
+            <a
+              href="#contact-information-download"
+              class="header-anchor svelte-1y7sq6j"
+              ><span class="anchor-icon" aria-hidden="true"
+                ><svg
+                  focusable="false"
+                  aria-hidden="true"
+                  class="icon-link svelte-1y7sq6j"
+                >
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  />
-                </svg>
-              </span>
-              <span class="visuallyhidden">Anchor link</span>
-            </a>
+                  ></path></svg
+              ></span>
+              <span class="visuallyhidden">Anchor link</span></a
+            >
           </h2>
           <div class="author-section">
-            <h3 id="author">
+            <h3 id="author-download" class="svelte-1y7sq6j">
               Author Information
-              <a href="#author" class="header-anchor">
-                <span class="anchor-icon" aria-hidden="true">
-                  <svg focusable="false" aria-hidden="true" class="icon-link">
+              <a href="#author-download" class="header-anchor svelte-1y7sq6j"
+                ><span class="anchor-icon" aria-hidden="true"
+                  ><svg
+                    focusable="false"
+                    aria-hidden="true"
+                    class="icon-link svelte-1y7sq6j"
+                  >
                     <path
                       d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                    />
-                  </svg>
-                </span>
-                <span class="visuallyhidden">Anchor link</span>
-              </a>
+                    ></path></svg
+                ></span>
+                <span class="visuallyhidden">Anchor link</span></a
+              >
             </h3>
             <ul>
               <li>Name: Mike Gifford</li>
@@ -124,34 +217,59 @@
               </li>
               <li>
                 Email:
-                <a href="mailto:mike.gifford@civicactions.com"
-                  >mike.gifford@civicactions.com</a
+                <a href="mailto:mike.gifford@civicactions.com" target="_blank"
+                  >mike.gifford@civicactions.com<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
               </li>
               <li>Phone: (510) 408-7510</li>
               <li>
                 Website:
-                <a href="https://civicactions.com/"
-                  >https://civicactions.com/</a
+                <a href="https://civicactions.com" target="_blank"
+                  >https://civicactions.com<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
               </li>
             </ul>
           </div>
+          <div class="vendor-section">
+            <h3 id="vendor-download" class="svelte-1y7sq6j">
+              Vendor Information
+              <a href="#vendor-download" class="header-anchor svelte-1y7sq6j"
+                ><span class="anchor-icon" aria-hidden="true"
+                  ><svg
+                    focusable="false"
+                    aria-hidden="true"
+                    class="icon-link svelte-1y7sq6j"
+                  >
+                    <path
+                      d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+                    ></path></svg
+                ></span>
+                <span class="visuallyhidden">Anchor link</span></a
+              >
+            </h3>
+            <ul></ul>
+          </div>
         </div>
-
         <div class="notes-section">
-          <h2 id="notes">
+          <h2 id="notes-download" class="svelte-1y7sq6j">
             Notes
-            <a href="#notes" class="header-anchor">
-              <span class="anchor-icon" aria-hidden="true">
-                <svg focusable="false" aria-hidden="true" class="icon-link">
+            <a href="#notes-download" class="header-anchor svelte-1y7sq6j"
+              ><span class="anchor-icon" aria-hidden="true"
+                ><svg
+                  focusable="false"
+                  aria-hidden="true"
+                  class="icon-link svelte-1y7sq6j"
+                >
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  />
-                </svg>
-              </span>
-              <span class="visuallyhidden">Anchor link</span>
-            </a>
+                  ></path></svg
+              ></span>
+              <span class="visuallyhidden">Anchor link</span></a
+            >
           </h2>
           <p>
             Links to the issues identified are included where possible to ensure
@@ -161,20 +279,24 @@
             Drupal community.
           </p>
         </div>
-
         <div class="eval-section">
-          <h2 id="evaluation-methods">
+          <h2 id="evaluation-methods-download" class="svelte-1y7sq6j">
             Evaluation Methods
-            <a href="#evaluation-methods" class="header-anchor">
-              <span class="anchor-icon" aria-hidden="true">
-                <svg focusable="false" aria-hidden="true" class="icon-link">
+            <a
+              href="#evaluation-methods-download"
+              class="header-anchor svelte-1y7sq6j"
+              ><span class="anchor-icon" aria-hidden="true"
+                ><svg
+                  focusable="false"
+                  aria-hidden="true"
+                  class="icon-link svelte-1y7sq6j"
+                >
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  />
-                </svg>
-              </span>
-              <span class="visuallyhidden">Anchor link</span>
-            </a>
+                  ></path></svg
+              ></span>
+              <span class="visuallyhidden">Anchor link</span></a
+            >
           </h2>
           <p>
             Use of automated tools like WAVE and Accessibility Insights. Manual
@@ -183,23 +305,33 @@
             accessibility issue queue.
           </p>
         </div>
-
         <div class="standards-section">
-          <h2 id="applicable-standards-guidelines">
+          <h2
+            id="applicable-standards-guidelines-download"
+            class="svelte-1y7sq6j"
+          >
             Applicable Standards/Guidelines
-            <a href="#applicable-standards-guidelines" class="header-anchor">
-              <span class="anchor-icon" aria-hidden="true">
-                <svg focusable="false" aria-hidden="true" class="icon-link">
+            <a
+              href="#applicable-standards-guidelines-download"
+              class="header-anchor svelte-1y7sq6j"
+              ><span class="anchor-icon" aria-hidden="true"
+                ><svg
+                  focusable="false"
+                  aria-hidden="true"
+                  class="icon-link svelte-1y7sq6j"
+                >
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  />
-                </svg>
-              </span>
-              <span class="visuallyhidden">Anchor link</span>
-            </a>
+                  ></path></svg
+              ></span>
+              <span class="visuallyhidden">Anchor link</span></a
+            >
           </h2>
-
-          <table class="usa-table applicable-standards-guidelines-table">
+          <table
+            class="usa-table applicable-standards-guidelines-table"
+            border="1"
+            style="border-collapse: collapse"
+          >
             <caption>
               This report covers the degree of conformance for the following
               accessibility standard/guidelines:
@@ -215,9 +347,8 @@
                 <td>
                   <a href="https://www.w3.org/TR/WCAG21/" target="_blank"
                     >Web Content Accessibility Guidelines 2.1<span
-                      class="usa-sr-only"
-                    >
-                      (opens in a new window or tab)</span
+                      class="visuallyhidden"
+                      >(opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -225,26 +356,29 @@
                   <ul>
                     <li>Table 1: Success Criteria, Level A</li>
                     <li>Table 2: Success Criteria, Level AA</li>
+                    <li>Table 3: Success Criteria, Level AAA</li>
                   </ul>
                 </td>
               </tr>
             </tbody>
           </table>
         </div>
-
         <div class="terms-section">
-          <h2 id="terms">
+          <h2 id="terms-download" class="svelte-1y7sq6j">
             Terms
-            <a href="#terms" class="header-anchor">
-              <span class="anchor-icon" aria-hidden="true">
-                <svg focusable="false" aria-hidden="true" class="icon-link">
+            <a href="#terms-download" class="header-anchor svelte-1y7sq6j"
+              ><span class="anchor-icon" aria-hidden="true"
+                ><svg
+                  focusable="false"
+                  aria-hidden="true"
+                  class="icon-link svelte-1y7sq6j"
+                >
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  />
-                </svg>
-              </span>
-              <span class="visuallyhidden">Anchor link</span>
-            </a>
+                  ></path></svg
+              ></span>
+              <span class="visuallyhidden">Anchor link</span></a
+            >
           </h2>
           The terms used in the Conformance Level information are defined as
           follows:
@@ -273,35 +407,40 @@
             </li>
           </ul>
         </div>
-
-        <h2 id="wcag-2.1">
+        <h2 id="wcag-2.1-download" class="svelte-1y7sq6j">
           WCAG 2.1 Report
-          <a href="#wcag-2.1" class="header-anchor">
-            <span class="anchor-icon" aria-hidden="true">
-              <svg focusable="false" aria-hidden="true" class="icon-link">
+          <a href="#wcag-2.1-download" class="header-anchor svelte-1y7sq6j"
+            ><span class="anchor-icon" aria-hidden="true"
+              ><svg
+                focusable="false"
+                aria-hidden="true"
+                class="icon-link svelte-1y7sq6j"
+              >
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                />
-              </svg>
-            </span>
-            <span class="visuallyhidden">Anchor link</span>
-          </a>
+                ></path></svg
+            ></span>
+            <span class="visuallyhidden">Anchor link</span></a
+          >
         </h2>
-
-        <h3 id="success_criteria_level_a">
+        <h3 id="success_criteria_level_a-download" class="svelte-1y7sq6j">
           Table 1: Success Criteria, Level A
-          <a href="#success_criteria_level_a" class="header-anchor">
-            <span class="anchor-icon" aria-hidden="true">
-              <svg focusable="false" aria-hidden="true" class="icon-link">
+          <a
+            href="#success_criteria_level_a-download"
+            class="header-anchor svelte-1y7sq6j"
+            ><span class="anchor-icon" aria-hidden="true"
+              ><svg
+                focusable="false"
+                aria-hidden="true"
+                class="icon-link svelte-1y7sq6j"
+              >
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                />
-              </svg>
-            </span>
-            <span class="visuallyhidden">Anchor link</span>
-          </a>
+                ></path></svg
+            ></span>
+            <span class="visuallyhidden">Anchor link</span></a
+          >
         </h3>
-
         <div id="success_criteria_level_a-notes" class="chapter-notes-section">
           Notes:
           <p>
@@ -316,47 +455,48 @@
             WCAG recommendation.
           </p>
         </div>
-
         <div id="success_criteria_level_a-summary">
           <p>
             Conformance to the 30 criteria listed below is distributed as
             follows:
           </p>
           <ul>
-            <li>40 supported</li>
-            <li>12 partially supported</li>
+            <li>32 supported</li>
+            <li>20 partially supported</li>
             <li>0 not supported</li>
             <li>68 not applicable</li>
           </ul>
         </div>
-
-        <table class="usa-table">
-          <thead>
-            <tr>
-              <th>Criteria</th>
-              <th>Conformance Level</th>
-              <th>Remarks and Explanations</th>
+        <table
+          class="usa-table svelte-1an8xyy"
+          border="1"
+          style="border-collapse: collapse"
+        >
+          <thead class="svelte-1an8xyy">
+            <tr class="svelte-1an8xyy">
+              <th class="svelte-1an8xyy">Criteria</th>
+              <th class="svelte-1an8xyy">Conformance Level</th>
+              <th class="svelte-1an8xyy">Remarks and Explanations</th>
             </tr>
           </thead>
           <tbody>
-            <tr id="1.1.1">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="non-text-content-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#non-text-content"
                   target="_blank"
+                  >1.1.1 Non-text Content<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.1.1 Non-text Content<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -378,34 +518,27 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
                     <p>
-                      Drupal core has no outstanding user barriers. There are
-                      improvements in the
+                      There are minor barriers which may present themselves to
+                      users. There are improvements in the
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111"
                         >outstanding issues</a
                       >
-                      which relate to decorative and the password strength
-                      indicator.
+                      which relate to decorative images and the password
+                      strength indicator. Status messages should be clearly
+                      marked as decorative. Most of the issues are tied to the
+                      administration interface.
                     </p>
                     <p>
-                      All open WCAG 1.1.1 issues: 3232414, 2514218, 3272325,
-                      3230231, 3275397, 3087535, 3319601
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>
-                      Some non-textual content in the documentation does not
-                      provide a textual alternative.
+                      All open WCAG 1.1.1 issue(s): 2921627, 3083994, 3232414,
+                      2514218, 3272325, 3230231, 3275397, 3087535, 3319601
                     </p>
                   </li>
                   <li>
@@ -423,7 +556,7 @@
                     <p>
                       Alternative text is required for images by default.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111"
                         >Outstanding issues</a
                       >
                       relate to thumbnail images, management of decorative
@@ -433,21 +566,22 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.2.1">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="audio-only-and-video-only-prerecorded-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#audio-only-and-video-only-prerecorded"
                   target="_blank"
+                  >1.2.1 Audio-only and Video-only (Prerecorded)<span
+                    class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.2.1 Audio-only and Video-only (Prerecorded)<span
-                    class="usa-sr-only"
-                  >
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -474,8 +608,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -484,12 +618,6 @@
                       Authors can satisfy 1.2.1 Audio-only and Video-only
                       (Prerecorded) by using text on the same page.
                     </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>This is not explicitly defined in the documentation.</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -503,19 +631,21 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.2.2">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="captions-prerecorded-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#captions-prerecorded"
                   target="_blank"
+                  >1.2.2 Captions (Prerecorded)<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.2.2 Captions (Prerecorded)<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -542,8 +672,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -567,20 +697,22 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.2.3">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="audio-description-or-media-alternative-prerecorded-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#audio-description-or-media-alternative-prerecorded"
                   target="_blank"
+                  >1.2.3 Audio Description or Media Alternative
+                  (Prerecorded)<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.2.3 Audio Description or Media Alternative
-                  (Prerecorded)<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -607,8 +739,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -616,15 +748,6 @@
                     <p>
                       Audio files can be uploaded, but there is no way to
                       associate captions in Core.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>
-                      There is no documentation on how to properly convey
-                      pre-recorded audio descriptions.
                     </p>
                   </li>
                   <li>
@@ -640,19 +763,21 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.3.1">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="info-and-relationships-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#info-and-relationships"
                   target="_blank"
+                  >1.3.1 Info and Relationships<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.3.1 Info and Relationships<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -679,8 +804,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -688,20 +813,21 @@
                     <p>
                       There are barriers in the
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag131"
                         >outstanding issues</a
                       >
                       ARIA landmarks and roles. There are also a number of
                       errors tied to forms (fieldsets, dates, radios &amp;
-                      checkboxes). There is also more work needed to provide
-                      better semantics for Voice Control and support for Windows
-                      High Contrast mode.
+                      checkboxes). More work is needed to provide better
+                      semantics for Voice Control and support for Windows High
+                      Contrast mode.
                     </p>
                     <p>
-                      All open WCAG 1.3.1 issues: 3081500, 2951317, 3098857,
-                      3347326, 3290899, 3171726, 2951714, 3144948, 3078334,
-                      2942404, 3190536, 3301868, 3171728, 3194669, 3200642,
-                      3206290, 3127469.
+                      All open WCAG 1.3.1 issue(s): 3182458, 3037726, 3037730,
+                      3037733, 3037725, 3037625, 2921627, 2937640, 3037446,
+                      3081500, 2951317, 3098857, 3347326, 3290899, 3171726,
+                      2951714, 3144948, 3078334, 2942404, 3190536, 3301868,
+                      3171728, 3194669, 3200642.
                     </p>
                   </li>
                   <li>
@@ -715,24 +841,30 @@
                       are also accessibility concerns with the vertical tabs and
                       dashboards available to users. Menu blocks are not getting
                       the correct ID in some instances.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag131"
+                        >Outstanding issues</a
+                      >.
                     </p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="1.3.2">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="meaningful-sequence-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#meaningful-sequence"
                   target="_blank"
+                  >1.3.2 Meaningful Sequence<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.3.2 Meaningful Sequence<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -743,7 +875,7 @@
                     <span class="component-level-label"
                       ><strong>Electronic Documents</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Not Applicable</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -759,8 +891,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -783,19 +915,21 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.3.3">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="sensory-characteristics-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#sensory-characteristics"
                   target="_blank"
+                  >1.3.3 Sensory Characteristics<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.3.3 Sensory Characteristics<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -822,8 +956,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -845,24 +979,23 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.4.1">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="use-of-color-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#use-of-color"
                   target="_blank"
+                  >1.4.1 Use of Color<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.4.1 Use of Color<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -884,15 +1017,25 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
                     <p>
-                      Color is not used without text and often symbols to convey
-                      meaning.
+                      Color is generally not used without text and often symbols
+                      to convey meaning.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag141"
+                        >Outstanding issues</a
+                      >
+                      are mostly tied to authoring tools, but table drag
+                      components may also be exposed to an unauthorized user.
+                    </p>
+                    <p>
+                      All open WCAG 1.4.1 issue(s): 3097907, 3171726, 3059168,
+                      867830
                     </p>
                   </li>
                   <li>
@@ -905,31 +1048,28 @@
                       tray, table drag, column severity and unpublished
                       articles.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag141"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag141"
                         >Outstanding issues</a
-                      >.
-                    </p>
-                    <p>
-                      All open WCAG 1.4.1 issues: 3097907, 3171726, 3281601,
-                      3059168, 867830.
+                      >
+                      also include the active toolbar tray, and the admin status
+                      report pages.
                     </p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="1.4.2">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="audio-control-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#audio-control"
                   target="_blank"
+                  >1.4.2 Audio Control<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.4.2 Audio Control<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -956,23 +1096,41 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4"></ul>
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>
+                      The file module in Core lets authors upload audio and
+                      video content, and output and elements and does not
+                      support captions.
+                    </p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>
+                      The file module in Core lets authors upload audio and
+                      video content, and output and elements and does not
+                      support captions.
+                    </p>
+                  </li>
+                </ul>
               </td>
             </tr>
-            <tr id="2.1.1">
-              <td>
-                <a
-                  href="https://www.w3.org/TR/WCAG21/#keyboard"
-                  target="_blank"
+            <tr class="result-row svelte-cn2gpq" id="keyboard-download">
+              <td class="svelte-cn2gpq">
+                <a href="https://www.w3.org/TR/WCAG21/#keyboard" target="_blank"
+                  >2.1.1 Keyboard<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.1.1 Keyboard<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -999,8 +1157,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1010,21 +1168,27 @@
                       with the keyboard and without specific timings for
                       individual keystrokes.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211"
                         >Outstanding issues</a
                       >
-                      with tooltips and the header menu.
+                      with tooltips and the header menu. There are also legacy
+                      issues with jQuery UI &amp; header menus. Items like
+                      datepickers can also be exposed to users.
                     </p>
-                    <p>All open WCAG 2.1.1 issues: 2933984, 3210434</p>
+                    <p>
+                      All open WCAG 2.1.1 issue(s): 3085811, 3229647, 3081515,
+                      2991686, 2911932, 3210434, 3038336, 2933984, 2852702
+                    </p>
                   </li>
                   <li>
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
-                      See remarks in Web section.
+                      Issues with the toolbar buttons, datepicker, contextual
+                      links, and tooltips. Also see remarks in Web section.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211"
                         >Outstanding issues</a
                       >.
                     </p>
@@ -1032,19 +1196,18 @@
                 </ul>
               </td>
             </tr>
-            <tr id="2.1.2">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="no-keyboard-trap-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#no-keyboard-trap"
                   target="_blank"
+                  >2.1.2 No Keyboard Trap<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.1.2 No Keyboard Trap<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1071,42 +1234,54 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
                     <p>
-                      Focus can be moved away from that component using only a
-                      keyboard interface.
+                      Users can move focus away from that component using only a
+                      keyboard interface. There is a known problem with the
+                      admin interface.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag212"
+                        >Outstanding issues</a
+                      >.
                     </p>
+                    <p>All open WCAG 2.1.2 issue(s): 2627788</p>
                   </li>
                   <li>
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
-                      Focus can be moved away from that component using only a
-                      keyboard interface.
+                      There is a known issue with focus states on text field
+                      AJAX calls.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag212"
+                        >Outstanding issues</a
+                      >.
                     </p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="2.1.4">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="character-key-shortcuts-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#character-key-shortcuts"
                   target="_blank"
+                  >2.1.4 Character Key Shortcuts<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.1.4 Character Key Shortcuts<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1133,8 +1308,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1150,19 +1325,21 @@
                 </ul>
               </td>
             </tr>
-            <tr id="2.2.1">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="timing-adjustable-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#timing-adjustable"
                   target="_blank"
+                  >2.2.1 Timing Adjustable<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.2.1 Timing Adjustable<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1189,8 +1366,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1206,19 +1383,18 @@
                 </ul>
               </td>
             </tr>
-            <tr id="2.2.2">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="pause-stop-hide-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#pause-stop-hide"
                   target="_blank"
+                  >2.2.2 Pause, Stop, Hide<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.2.2 Pause, Stop, Hide<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1245,8 +1421,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1262,21 +1438,22 @@
                 </ul>
               </td>
             </tr>
-            <tr id="2.3.1">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="three-flashes-or-below-threshold-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#three-flashes-or-below-threshold"
                   target="_blank"
+                  >2.3.1 Three Flashes or Below Threshold<span
+                    class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.3.1 Three Flashes or Below Threshold<span
-                    class="usa-sr-only"
-                  >
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1303,8 +1480,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1320,19 +1497,18 @@
                 </ul>
               </td>
             </tr>
-            <tr id="2.4.1">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="bypass-blocks-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#bypass-blocks"
                   target="_blank"
+                  >2.4.1 Bypass Blocks<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.4.1 Bypass Blocks<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1359,17 +1535,11 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
-                    </span>
-                    <p>Skip links are provided.</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
                     </span>
                     <p>Skip links are provided.</p>
                   </li>
@@ -1382,160 +1552,23 @@
                 </ul>
               </td>
             </tr>
-            <tr id="2.4.2">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="page-titled-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#page-titled"
                   target="_blank"
+                  >2.4.2 Page Titled<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.4.2 Page Titled<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Supports</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>Not Applicable</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Software</strong>:
-                    </span>
-                    <p>Not Applicable</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Authoring Tool</strong>:
-                    </span>
-                    <p>Supports</p>
-                  </li>
-                </ul>
-              </td>
-              <td>
-                <ul class="component-level-count-4">
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Web</strong>:
-                    </span>
-                    <p>Pages are titled correctly.</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Authoring Tool</strong>:
-                    </span>
-                    <p>
-                      Generally, pages are titled correctly.
-                      <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242"
-                        >Outstanding issues</a
-                      >
-                      with a regression in how fields are displayed in editing
-                      content types.
-                    </p>
-                    <p>All open WCAG 2.4.2 issues: 2514218</p>
-                  </li>
-                </ul>
-              </td>
-            </tr>
-            <tr id="2.4.3">
-              <td>
-                <a
-                  href="https://www.w3.org/TR/WCAG21/#focus-order"
-                  target="_blank"
-                >
-                  2.4.3 Focus Order<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
-              </td>
-              <td>
-                <ul class="component-level-count-4">
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Web</strong>:
-                    </span>
-                    <p>Supports</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>Not Applicable</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Software</strong>:
-                    </span>
-                    <p>Not Applicable</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Authoring Tool</strong>:
-                    </span>
-                    <p>Supports</p>
-                  </li>
-                </ul>
-              </td>
-              <td>
-                <ul class="component-level-count-4">
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Web</strong>:
-                    </span>
-                    <p>
-                      Focusable components receive focus in an order that
-                      preserves meaning and operability.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>
-                      Focusable components receive focus in an order that
-                      preserves meaning and operability.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Authoring Tool</strong>:
-                    </span>
-                    <p>
-                      Focusable components receive focus in an order that
-                      preserves meaning and operability.
-                    </p>
-                  </li>
-                </ul>
-              </td>
-            </tr>
-            <tr id="2.4.4">
-              <td>
-                <a
-                  href="https://www.w3.org/TR/WCAG21/#link-purpose-in-context"
-                  target="_blank"
-                >
-                  2.4.4 Link Purpose (In Context)<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
-              </td>
-              <td>
-                <ul class="component-level-count-4">
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Web</strong>:
-                    </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -1557,8 +1590,160 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>
+                      Pages are titled for users correctly. There is an
+                      outstanding issue for authors.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242"
+                        >Outstanding issues</a
+                      >
+                      are tied to pagination.
+                    </p>
+                    <p>All open WCAG 2.1.2 issue(s): 2514218, 2509716</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>
+                      Generally, pages are titled correctly.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242"
+                        >Outstanding issues</a
+                      >
+                      with a regression in how fields are displayed in editing
+                      content types.
+                    </p>
+                  </li>
+                </ul>
+              </td>
+            </tr>
+            <tr class="result-row svelte-cn2gpq" id="focus-order-download">
+              <td class="svelte-cn2gpq">
+                <a
+                  href="https://www.w3.org/TR/WCAG21/#focus-order"
+                  target="_blank"
+                  >2.4.3 Focus Order<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
+                >
+              </td>
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>Partially Supports</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Electronic Documents</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Software</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>Partially Supports</p>
+                  </li>
+                </ul>
+              </td>
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>
+                      Generally, focusable components receive focus in an order
+                      that preserves meaning and operability. Most of these
+                      issues are tied to the administration interface.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag243"
+                        >Outstanding issues</a
+                      >.
+                    </p>
+                    <p>
+                      All open WCAG 2.1.2 issue(s): 3019849, 3042107, 3047730,
+                      2973114, 2925295, 3273086
+                    </p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>
+                      Generally, focusable components receive focus in an order
+                      that preserves meaning and operability.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag243"
+                        >Outstanding issues</a
+                      >. Some elements of the authoring interface to don't
+                      return the focus where an editor should expect it to.
+                      There are elements with table drag and Layout Builder
+                      which should be addressed.
+                    </p>
+                  </li>
+                </ul>
+              </td>
+            </tr>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="link-purpose-in-context-download"
+            >
+              <td class="svelte-cn2gpq">
+                <a
+                  href="https://www.w3.org/TR/WCAG21/#link-purpose-in-context"
+                  target="_blank"
+                  >2.4.4 Link Purpose (In Context)<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
+                >
+              </td>
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>Partially Supports</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Electronic Documents</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Software</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>Partially Supports</p>
+                  </li>
+                </ul>
+              </td>
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1567,6 +1752,14 @@
                       Careful attention has been paid to ensure that automated
                       "Read More" links are available in a way that is available
                       with contextual information for screen readers.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag244"
+                        >Outstanding issues</a
+                      >
+                      can be tied to user comments.
+                    </p>
+                    <p>
+                      All open WCAG 2.4.4 issue(s): 2922435, 3351638, 2852898
                     </p>
                   </li>
                   <li>
@@ -1576,30 +1769,28 @@
                     <p>
                       Generally very well-supported.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag244"
                         >Outstanding issues</a
                       >
                       with truncation of the path alias and duplicate links on
                       edit content page.
                     </p>
-                    <p>All open WCAG 2.4.2 issues: 3351638, 2852898</p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="2.5.1">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="pointer-gestures-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#pointer-gestures"
                   target="_blank"
+                  >2.5.1 Pointer Gestures<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.5.1 Pointer Gestures<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1622,17 +1813,17 @@
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>Not Applicable</p>
+                    <p>Supports</p>
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>No known challenges with pointer gestures.</p>
+                    <p>Pointer gestures are generally very good.</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -1643,19 +1834,21 @@
                 </ul>
               </td>
             </tr>
-            <tr id="2.5.2">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="pointer-cancellation-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#pointer-cancellation"
                   target="_blank"
+                  >2.5.2 Pointer Cancellation<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.5.2 Pointer Cancellation<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1682,14 +1875,23 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
                     <p>
-                      No known problems for users with pointer cancellation.
+                      No known problems for users with pointer cancellation for
+                      users.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag252"
+                        >Outstanding issue(s)</a
+                      >.
+                    </p>
+                    <p>
+                      All open WCAG 2.5.2 issue(s): 2616184, 2968637, 2960840,
+                      2958654
                     </p>
                   </li>
                   <li>
@@ -1700,30 +1902,28 @@
                       The Drupal ajax framework uses 'mousedown' to capture the
                       click.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag252"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag252"
                         >Outstanding issue(s)</a
                       >
                       with truncation of the path alias and duplicate links on
                       edit content page.
                     </p>
-                    <p>All open WCAG 2.5.2 issue(s): 2616184</p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="2.5.3">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="label-in-name-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#label-in-name"
                   target="_blank"
+                  >2.5.3 Label in Name<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.5.3 Label in Name<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1750,8 +1950,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1767,19 +1967,18 @@
                 </ul>
               </td>
             </tr>
-            <tr id="2.5.4">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="motion-actuation-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#motion-actuation"
                   target="_blank"
+                  >2.5.4 Motion Actuation<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.5.4 Motion Actuation<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1806,8 +2005,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1823,19 +2022,18 @@
                 </ul>
               </td>
             </tr>
-            <tr id="3.1.1">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="language-of-page-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#language-of-page"
                   target="_blank"
+                  >3.1.1 Language of Page<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  3.1.1 Language of Page<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1862,8 +2060,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1872,38 +2070,23 @@
                   </li>
                   <li>
                     <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>Page language is defined semantically on every page.</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>
-                      <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag311"
-                        >Outstanding issues</a
-                      >.
-                    </p>
-                    <p>All open WCAG 3.1.1 issue(s): 3081526</p>
+                    <p>Page language is defined semantically on every page.</p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="3.2.1">
-              <td>
-                <a
-                  href="https://www.w3.org/TR/WCAG21/#on-focus"
-                  target="_blank"
+            <tr class="result-row svelte-cn2gpq" id="on-focus-download">
+              <td class="svelte-cn2gpq">
+                <a href="https://www.w3.org/TR/WCAG21/#on-focus" target="_blank"
+                  >3.2.1 On Focus<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  3.2.1 On Focus<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1930,20 +2113,11 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
-                    </span>
-                    <p>
-                      Change in the focus state does not initiate a change of
-                      context for the user.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
                     </span>
                     <p>
                       Change in the focus state does not initiate a change of
@@ -1962,19 +2136,16 @@
                 </ul>
               </td>
             </tr>
-            <tr id="3.2.2">
-              <td>
-                <a
-                  href="https://www.w3.org/TR/WCAG21/#on-input"
-                  target="_blank"
+            <tr class="result-row svelte-cn2gpq" id="on-input-download">
+              <td class="svelte-cn2gpq">
+                <a href="https://www.w3.org/TR/WCAG21/#on-input" target="_blank"
+                  >3.2.2 On Input<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  3.2.2 On Input<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2001,20 +2172,11 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
-                    </span>
-                    <p>
-                      Engaging with the interactive sites does not unexpectedly
-                      take control from the users.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
                     </span>
                     <p>
                       Engaging with the interactive sites does not unexpectedly
@@ -2033,19 +2195,21 @@
                 </ul>
               </td>
             </tr>
-            <tr id="3.3.1">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="error-identification-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#error-identification"
                   target="_blank"
+                  >3.3.1 Error Identification<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  3.3.1 Error Identification<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2072,8 +2236,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2082,15 +2246,15 @@
                       The Inline Form Error module needs to be enabled site-wide
                       on installation.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag311"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag331"
                         >Outstanding issues</a
                       >. Most of these issues are also authoring interface, but
                       there are problems with HTML5 validation, child groupings,
                       required errors, and file uploading.
                     </p>
                     <p>
-                      All open WCAG 3.3.1 issues: 3059955, 1797438, 2848507,
-                      2563173, 3087305, 2455933, 3087402, 2847425, 2089703
+                      All open WCAG 3.3.1 issue(s): 2848307, 2560467, 2876321,
+                      3279596, 3087385, 3059955, 1797438, 2848507, 2563173
                     </p>
                   </li>
                   <li>
@@ -2100,7 +2264,7 @@
                     <p>
                       See the Web section as most of these
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag311"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag331"
                         >outstanding issues</a
                       >
                       are also likely on the user side.
@@ -2109,19 +2273,21 @@
                 </ul>
               </td>
             </tr>
-            <tr id="3.3.2">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="labels-or-instructions-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#labels-or-instructions"
                   target="_blank"
+                  >3.3.2 Labels or Instructions<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  3.3.2 Labels or Instructions<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2148,8 +2314,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2157,13 +2323,17 @@
                     <p>
                       Default forms all include labels.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332"
                         >Outstanding issues</a
                       >
                       include a lack of 'aria-describedby' and grouped fields
-                      missing labels.
+                      missing labels. There are some exceptions like Views
+                      search filter label isn't associated with the input.
                     </p>
-                    <p>All open WCAG 3.3.2 issues: 2998857, 2608212</p>
+                    <p>
+                      All open WCAG 3.3.2 issue(s): 2608180, 2942037, 3037446,
+                      2998857, 2608212
+                    </p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2174,24 +2344,25 @@
                       labels, but these are odd exceptions. See the Web section
                       for details.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332"
                         >Outstanding issues</a
-                      >.
+                      >. There are known issues with the Admin list filter and
+                      grouped publishing status messages.
                     </p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="4.1.1">
-              <td>
-                <a href="https://www.w3.org/TR/WCAG21/#parsing" target="_blank">
-                  4.1.1 Parsing<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
+            <tr class="result-row svelte-cn2gpq" id="parsing-download">
+              <td class="svelte-cn2gpq">
+                <a href="https://www.w3.org/TR/WCAG21/#parsing" target="_blank"
+                  >4.1.1 Parsing<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
+                >
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2218,8 +2389,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2227,16 +2398,12 @@
                     <p>
                       There are no HTML5 errors or warnings that are known to
                       impact assistive technology users.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag411"
+                        >Outstanding issues</a
+                      >.
                     </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>
-                      There are no HTML5 errors or warnings that are known to
-                      impact assistive technology users.
-                    </p>
+                    <p>All open WCAG 4.1.1 issue(s): 3174459</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2246,33 +2413,32 @@
                       Generally parsing is very well-supported, but there are a
                       few places where this needs to be improved.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag411"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag411"
                         >Outstanding issues</a
-                      >.
+                      >. There is an error identified with fields in articles
+                      that has not been independently validated.
                     </p>
-                    <p>All open WCAG 4.1.1 issue(s): 3174459</p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="4.1.2">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="name-role-value-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#name-role-value"
                   target="_blank"
+                  >4.1.2 Name, Role, Value<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  4.1.2 Name, Role, Value<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2294,19 +2460,24 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Public pages support this criterion.</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>Public pages support this criterion.</p>
+                    <p>
+                      Public pages generally support this criterion.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag412"
+                        >Outstanding issues</a
+                      >. There are issues when Views List is filtered.
+                    </p>
+                    <p>
+                      All open WCAG 4.1.2 issue(s): 3050559, 2805499, 2913378,
+                      2805227, 1096124, 2047089, 3272316, 2942232, 3087313,
+                      2719453
+                    </p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2316,14 +2487,10 @@
                       This is generally well-supported, but there are places
                       where it has been overlooked.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag412"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag412"
                         >Outstanding issues</a
                       >. There are semantics missing for aria elements in the
-                      block, forms, and contextual modules.
-                    </p>
-                    <p>
-                      All open WCAG 4.1.2 issues: 3083181, 2852724, 3218877,
-                      3028780, 1852090, 3085545
+                      block, forms, media, bulk actions and contextual modules.
                     </p>
                   </li>
                 </ul>
@@ -2331,21 +2498,24 @@
             </tr>
           </tbody>
         </table>
-
-        <h3 id="success_criteria_level_aa">
+        <h3 id="success_criteria_level_aa-download" class="svelte-1y7sq6j">
           Table 2: Success Criteria, Level AA
-          <a href="#success_criteria_level_aa" class="header-anchor">
-            <span class="anchor-icon" aria-hidden="true">
-              <svg focusable="false" aria-hidden="true" class="icon-link">
+          <a
+            href="#success_criteria_level_aa-download"
+            class="header-anchor svelte-1y7sq6j"
+            ><span class="anchor-icon" aria-hidden="true"
+              ><svg
+                focusable="false"
+                aria-hidden="true"
+                class="icon-link svelte-1y7sq6j"
+              >
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                />
-              </svg>
-            </span>
-            <span class="visuallyhidden">Anchor link</span>
-          </a>
+                ></path></svg
+            ></span>
+            <span class="visuallyhidden">Anchor link</span></a
+          >
         </h3>
-
         <div id="success_criteria_level_aa-summary">
           <p>
             Conformance to the 20 criteria listed below is distributed as
@@ -2353,34 +2523,36 @@
           </p>
           <ul>
             <li>24 supported</li>
-            <li>11 partially supported</li>
-            <li>3 not supported</li>
-            <li>32 not applicable</li>
+            <li>13 partially supported</li>
+            <li>2 not supported</li>
+            <li>40 not applicable</li>
           </ul>
         </div>
-
-        <table class="usa-table">
-          <thead>
-            <tr>
-              <th>Criteria</th>
-              <th>Conformance Level</th>
-              <th>Remarks and Explanations</th>
+        <table
+          class="usa-table svelte-1an8xyy"
+          border="1"
+          style="border-collapse: collapse"
+        >
+          <thead class="svelte-1an8xyy">
+            <tr class="svelte-1an8xyy">
+              <th class="svelte-1an8xyy">Criteria</th>
+              <th class="svelte-1an8xyy">Conformance Level</th>
+              <th class="svelte-1an8xyy">Remarks and Explanations</th>
             </tr>
           </thead>
           <tbody>
-            <tr id="1.2.4">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="captions-live-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#captions-live"
                   target="_blank"
+                  >1.2.4 Captions (Live)<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.2.4 Captions (Live)<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2407,32 +2579,39 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
                     <p>This is not a feature supported in Drupal Core.</p>
                   </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>This is not a feature supported in Drupal Core.</p>
+                  </li>
                 </ul>
               </td>
             </tr>
-            <tr id="1.2.5">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="audio-description-prerecorded-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#audio-description-prerecorded"
                   target="_blank"
+                  >1.2.5 Audio Description (Prerecorded)<span
+                    class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.2.5 Audio Description (Prerecorded)<span
-                    class="usa-sr-only"
-                  >
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2443,7 +2622,7 @@
                     <span class="component-level-label"
                       ><strong>Electronic Documents</strong>:
                     </span>
-                    <p>Does Not Support</p>
+                    <p>Not Applicable</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2459,8 +2638,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2468,15 +2647,6 @@
                     <p>
                       Audio files can be uploaded, but there is no way to
                       associate captions in Core.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>
-                      There is no documentation on how to properly convey
-                      pre-recorded audio descriptions.
                     </p>
                   </li>
                   <li>
@@ -2492,55 +2662,134 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.3.4">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="orientation-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#orientation"
                   target="_blank"
+                  >1.3.4 Orientation<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.3.4 Orientation<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-0"></ul>
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>Supports</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Electronic Documents</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Software</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>Supports</p>
+                  </li>
+                </ul>
               </td>
-              <td>
-                <ul class="component-level-count-0"></ul>
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>No known problems with orientation.</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>No known problems with orientation.</p>
+                  </li>
+                </ul>
               </td>
             </tr>
-            <tr id="1.3.5">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="identify-input-purpose-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#identify-input-purpose"
                   target="_blank"
+                  >1.3.5 Identify Input Purpose<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.3.5 Identify Input Purpose<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-0"></ul>
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>Supports</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Electronic Documents</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Software</strong>:
+                    </span>
+                    <p>Not Applicable</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>Supports</p>
+                  </li>
+                </ul>
               </td>
-              <td>
-                <ul class="component-level-count-0"></ul>
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>No known problems with input purpose.</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Authoring Tool</strong>:
+                    </span>
+                    <p>No known problems with input purpose.</p>
+                  </li>
+                </ul>
               </td>
             </tr>
-            <tr id="1.4.3">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="visual-audio-contrast-contrast-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-contrast"
                   target="_blank"
+                  >1.4.3 Contrast (Minimum)<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.4.3 Contrast (Minimum)<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2567,8 +2816,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2579,20 +2828,14 @@
                       form labels, disabled form elements, and some dialogs
                       require additional contrast to meet 1.4.3 requirements.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143"
                         >Outstanding issues</a
                       >.
                     </p>
                     <p>
-                      All open WCAG 1.4.3 issue(s): 3266299, 3040673, 3231744,
-                      3200635, 2756483, 2725539, 3076153
+                      All open WCAG 1.4.3 issue(s): 3271652, 3318394, 3266299,
+                      3040673, 3231744, 3200635, 2756483, 2725539, 3076153
                     </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>The docs have sufficient contrast.</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2602,7 +2845,7 @@
                       Generally meets requirements. Form elements described in
                       the web section affect both user and author interfaces.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143"
                         >Outstanding issues</a
                       >.
                     </p>
@@ -2610,19 +2853,21 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.4.4">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="visual-audio-contrast-scale-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-scale"
                   target="_blank"
+                  >1.4.4 Resize text<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.4.4 Resize text<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2649,8 +2894,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2659,17 +2904,11 @@
                       Generally support with a minor exception with focus
                       outlines.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144"
                         >Outstanding issues</a
                       >.
                     </p>
-                    <p>All WCAG 1.4.4 issues: 3068698, 3238618</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>The docs are accessible up to 200%.</p>
+                    <p>All WCAG 1.4.4 issue(s): 3068698, 3238618, 2384203</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -2679,7 +2918,7 @@
                       Generally support with some minor exception with limited
                       horizontal space.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144"
                         >Outstanding issues</a
                       >.
                     </p>
@@ -2687,19 +2926,21 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.4.5">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="visual-audio-contrast-text-presentation-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-text-presentation"
                   target="_blank"
+                  >1.4.5 Images of Text<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.4.5 Images of Text<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2726,8 +2967,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2747,16 +2988,16 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.4.10">
-              <td>
-                <a href="https://www.w3.org/TR/WCAG21/#reflow" target="_blank">
-                  1.4.10 Reflow<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
+            <tr class="result-row svelte-cn2gpq" id="reflow-download">
+              <td class="svelte-cn2gpq">
+                <a href="https://www.w3.org/TR/WCAG21/#reflow" target="_blank"
+                  >1.4.10 Reflow<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
+                >
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2783,8 +3024,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2793,13 +3034,13 @@
                       Generally meets. Some issues with long words, responsive
                       tables, resizing menus, and wide screen layout.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410"
                         >Outstanding issues</a
                       >.
                     </p>
                     <p>
-                      All open WCAG 1.4.10 issues: 3159896, 3177475, 2280035,
-                      3191806, 2574721, 3164587.
+                      All open WCAG 1.4.10 issue(s): 2313471, 3159896, 3177475,
+                      2280035, 3191806, 2574721, 3164587
                     </p>
                   </li>
                   <li>
@@ -2812,7 +3053,7 @@
                       some minor exception with the action links on the modules
                       page.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410"
                         >Outstanding issues</a
                       >.
                     </p>
@@ -2820,19 +3061,21 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.4.11">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="non-text-contrast-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#non-text-contrast"
                   target="_blank"
+                  >1.4.11 Non-text Contrast<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.4.11 Non-text Contrast<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2859,8 +3102,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2869,13 +3112,14 @@
                       Generally meets. There are still some images that need to
                       have their contrast increased.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411"
                         >Outstanding issues</a
                       >.
                     </p>
                     <p>
-                      All open WCAG 1.4.11 issues: 3097907, 2910102, 3171726,
-                      3272266, 3037742
+                      All open WCAG 1.4.11 issue(s): 3273806, 3270130, 3269420,
+                      3269342, 3277262, 2990766, 3097907, 2910102, 3171726,
+                      3272266
                     </p>
                   </li>
                   <li>
@@ -2889,7 +3133,7 @@
                     </p>
                     <p>
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411"
                         >Outstanding issues</a
                       >.
                     </p>
@@ -2897,19 +3141,18 @@
                 </ul>
               </td>
             </tr>
-            <tr id="1.4.12">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="text-spacing-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#text-spacing"
                   target="_blank"
+                  >1.4.12 Text Spacing<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.4.12 Text Spacing<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2936,8 +3179,21 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Web</strong>:
+                    </span>
+                    <p>
+                      All known related issues are tied to the admin interface.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1412"
+                        >Outstanding issues</a
+                      >.
+                    </p>
+                    <p>All open WCAG 1.4.12 issue(s): 2919837</p>
+                  </li>
                   <li>
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
@@ -2946,28 +3202,29 @@
                       Generally supports. There is a known issue with off-canvas
                       dialogs.
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1412"
                         >Outstanding issues</a
                       >.
                     </p>
-                    <p>All open WCAG 1.4.12 issues: 2919837</p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="1.4.13">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="content-on-hover-or-focus-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus"
                   target="_blank"
+                  >1.4.13 Content on Hover or Focus<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  1.4.13 Content on Hover or Focus<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2994,8 +3251,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3011,19 +3268,18 @@
                 </ul>
               </td>
             </tr>
-            <tr id="2.4.5">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="multiple-ways-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#multiple-ways"
                   target="_blank"
+                  >2.4.5 Multiple Ways<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.4.5 Multiple Ways<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3050,20 +3306,11 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
-                    </span>
-                    <p>
-                      There is more than one way to locate a Web page within the
-                      CMS.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
                     </span>
                     <p>
                       There is more than one way to locate a Web page within the
@@ -3082,19 +3329,21 @@
                 </ul>
               </td>
             </tr>
-            <tr id="2.4.6">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="headings-and-labels-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#headings-and-labels"
                   target="_blank"
+                  >2.4.6 Headings and Labels<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.4.6 Headings and Labels<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3117,40 +3366,58 @@
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>Generally there is very good support.</p>
+                    <p>
+                      Generally there is very good support.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag246"
+                        >Outstanding issues</a
+                      >
+                      are for the admin interface.
+                    </p>
+                    <p>
+                      All open WCAG 2.4.6 issue(s): 3232222, 3277785, 2614950,
+                      3333401, 3293673
+                    </p>
                   </li>
                   <li>
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>Generally good.</p>
+                    <p>
+                      Generally good.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag246"
+                        >Outstanding issues</a
+                      >
+                      are tied to header for the pager template can be outside
+                      the document hierarchy order.
+                    </p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="2.4.7">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="focus-visible-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#focus-visible"
                   target="_blank"
+                  >2.4.7 Focus Visible<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  2.4.7 Focus Visible<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3177,14 +3444,23 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
                     <p>
-                      Focus elements are well established for the front-end.
+                      Generally there is very good support.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag247"
+                        >Outstanding issues</a
+                      >.
+                    </p>
+                    <p>
+                      All open WCAG 2.4.7 issue(s): 2990588, 2822778, 3273054,
+                      3200584, 3191727, 3270230, 3091534, 3335411, 3302103,
+                      3273099
                     </p>
                   </li>
                   <li>
@@ -3192,32 +3468,34 @@
                       ><strong>Authoring Tool</strong>:
                     </span>
                     <p>
-                      Generally supports. There is a known
+                      Generally supports. There is an
                       <a
-                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag247"
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag247"
                         >outstanding issues</a
                       >. A block can be added with layout builder that stops
                       authors from escaping focus. The image style page also has
-                      a hidden focus element.
+                      a hidden focus element. There are issues with modal popups
+                      in Views and with Toolbar focus styles.
                     </p>
-                    <p>All open WCAG 2.47 issues: 3302103, 3273099</p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="3.1.2">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="language-of-parts-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#language-of-parts"
                   target="_blank"
+                  >3.1.2 Language of Parts<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  3.1.2 Language of Parts<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3244,17 +3522,26 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
                     <p>
                       Multilingual sites have language switchers with proper
-                      semantics. Unfotunately support is lacking for
-                      multi-lingual search 2992894 as well as both the
-                      Filesystem 3163915 &amp; Views components 2496223.
+                      semantics. Unfortunately support is lacking for
+                      multilingual search as well as both the Filesystem and
+                      Views components.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag312"
+                        >Outstanding issues</a
+                      >.
+                    </p>
+                    <p>
+                      All open WCAG 3.1.2 issue(s): 3300835, 3361370, 3361375,
+                      3362791, 2036277, 3300836, 3042984, 82751, 3163915,
+                      3049122
                     </p>
                   </li>
                   <li>
@@ -3266,24 +3553,31 @@
                       accessibility. To support the Language of Parts for
                       authors, a button can be added to simplify the process of
                       adding language specific phrases.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag312"
+                        >Outstanding issues</a
+                      >. There are untranslatable fields in parts of the
+                      administration interface that are known.
                     </p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="3.2.3">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="consistent-navigation-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#consistent-navigation"
                   target="_blank"
+                  >3.2.3 Consistent Navigation<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  3.2.3 Consistent Navigation<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-3">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3294,18 +3588,24 @@
                     <span class="component-level-label"
                       ><strong>Electronic Documents</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Not Applicable</p>
                   </li>
                   <li>
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Partially Supports</p>
+                  </li>
+                  <li>
+                    <span class="component-level-label"
+                      ><strong>Software</strong>:
+                    </span>
+                    <p>Not Applicable</p>
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-3">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3313,15 +3613,14 @@
                     <p>
                       Drupal's menu structure allows for consistent navigation
                       across the site.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag323"
+                        >Outstanding issues</a
+                      >. There are some minor issues with mobile in Olivero.
                     </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
                     <p>
-                      Drupal's menu structure allows for consistent navigation
-                      across the site.
+                      All open WCAG 3.2.3 issue(s): 3129257, 3209129, 3350947,
+                      3084554, 2895388
                     </p>
                   </li>
                   <li>
@@ -3331,24 +3630,31 @@
                     <p>
                       Drupal's menu structure allows for consistent navigation
                       across the site.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag323"
+                        >Outstanding issues</a
+                      >. There are issues with scrolling with layout builder and
+                      with the Modules Uninstall filter.
                     </p>
                   </li>
                 </ul>
               </td>
             </tr>
-            <tr id="3.2.4">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="consistent-identification-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#consistent-identification"
                   target="_blank"
+                  >3.2.4 Consistent Identification<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  3.2.4 Consistent Identification<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-3">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-3 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3359,7 +3665,7 @@
                     <span class="component-level-label"
                       ><strong>Electronic Documents</strong>:
                     </span>
-                    <p>Supports</p>
+                    <p>Not Applicable</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -3369,20 +3675,11 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-3">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-3 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
-                    </span>
-                    <p>
-                      Components in Drupal that have the same functionality are
-                      identified consistently.
-                    </p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
                     </span>
                     <p>
                       Components in Drupal that have the same functionality are
@@ -3401,19 +3698,18 @@
                 </ul>
               </td>
             </tr>
-            <tr id="3.3.3">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="error-suggestion-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#error-suggestion"
                   target="_blank"
+                  >3.3.3 Error Suggestion<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  3.3.3 Error Suggestion<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3440,8 +3736,8 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3463,21 +3759,22 @@
                 </ul>
               </td>
             </tr>
-            <tr id="3.3.4">
-              <td>
+            <tr
+              class="result-row svelte-cn2gpq"
+              id="error-prevention-legal-financial-data-download"
+            >
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#error-prevention-legal-financial-data"
                   target="_blank"
+                  >3.3.4 Error Prevention (Legal, Financial, Data)<span
+                    class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  3.3.4 Error Prevention (Legal, Financial, Data)<span
-                    class="usa-sr-only"
-                  >
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3504,19 +3801,13 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
                     <p>By default users can editing content which they own.</p>
-                  </li>
-                  <li>
-                    <span class="component-level-label"
-                      ><strong>Electronic Documents</strong>:
-                    </span>
-                    <p>Documentation could be improved.</p>
                   </li>
                   <li>
                     <span class="component-level-label"
@@ -3530,19 +3821,18 @@
                 </ul>
               </td>
             </tr>
-            <tr id="4.1.3">
-              <td>
+            <tr class="result-row svelte-cn2gpq" id="status-messages-download">
+              <td class="svelte-cn2gpq">
                 <a
                   href="https://www.w3.org/TR/WCAG21/#status-messages"
                   target="_blank"
+                  >4.1.3 Status Messages<span class="visuallyhidden"
+                    >(opens in a new window or tab)</span
+                  ></a
                 >
-                  4.1.3 Status Messages<span class="usa-sr-only">
-                    (opens in a new window or tab)</span
-                  >
-                </a>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3569,38 +3859,86 @@
                   </li>
                 </ul>
               </td>
-              <td>
-                <ul class="component-level-count-4">
+              <td class="svelte-cn2gpq">
+                <ul class="component-level-count-4 svelte-cn2gpq">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
                     </span>
-                    <p>No known problems with status messages.</p>
+                    <p>
+                      No known problems with status messages.
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag413"
+                        >Outstanding issues</a
+                      >.
+                    </p>
+                    <p>
+                      All open WCAG 4.1.3 issue(s): 2973116, 2893663, 3035435,
+                      3159933, 2973140
+                    </p>
                   </li>
                   <li>
                     <span class="component-level-label"
                       ><strong>Authoring Tool</strong>:
                     </span>
-                    <p>No known problems with status messages.</p>
+                    <p>
+                      <a
+                        href="https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag413"
+                        >Outstanding issues</a
+                      >
+                      are known after enabling/disabling a View, with the
+                      dropdown buttons, and with progress messages.
+                    </p>
                   </li>
                 </ul>
               </td>
             </tr>
           </tbody>
         </table>
-
-        <h2 id="legal-disclaimer">
-          Legal Disclaimer
-          <a href="#legal-disclaimer" class="header-anchor">
-            <span class="anchor-icon" aria-hidden="true">
-              <svg focusable="false" aria-hidden="true" class="icon-link">
+        <h3 id="success_criteria_level_aaa-download" class="svelte-1y7sq6j">
+          Table 3: Success Criteria, Level AAA
+          <a
+            href="#success_criteria_level_aaa-download"
+            class="header-anchor svelte-1y7sq6j"
+            ><span class="anchor-icon" aria-hidden="true"
+              ><svg
+                focusable="false"
+                aria-hidden="true"
+                class="icon-link svelte-1y7sq6j"
+              >
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                />
-              </svg>
-            </span>
-            <span class="visuallyhidden">Anchor link</span>
-          </a>
+                ></path></svg
+            ></span>
+            <span class="visuallyhidden">Anchor link</span></a
+          >
+        </h3>
+        <div
+          id="success_criteria_level_aaa-notes"
+          class="chapter-notes-section"
+        >
+          Notes:
+          <p>
+            Where possible the Drupal community strives to exceed AA compliance.
+          </p>
+        </div>
+        <h2 id="legal-disclaimer-download" class="svelte-1y7sq6j">
+          Legal Disclaimer
+          <a
+            href="#legal-disclaimer-download"
+            class="header-anchor svelte-1y7sq6j"
+            ><span class="anchor-icon" aria-hidden="true"
+              ><svg
+                focusable="false"
+                aria-hidden="true"
+                class="icon-link svelte-1y7sq6j"
+              >
+                <path
+                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+                ></path></svg
+            ></span>
+            <span class="visuallyhidden">Anchor link</span></a
+          >
         </h2>
         <p>
           The information herein is provided in good faith based on the analysis
@@ -3609,60 +3947,89 @@
           accessibility errors or conformance claim errors for re-evaluation and
           correction, if necessary.
         </p>
-
-        <h2 id="repository">
+        <h2 id="repository-download" class="svelte-1y7sq6j">
           Repository
-          <a href="#repository" class="header-anchor">
-            <span class="anchor-icon" aria-hidden="true">
-              <svg focusable="false" aria-hidden="true" class="icon-link">
+          <a href="#repository-download" class="header-anchor svelte-1y7sq6j"
+            ><span class="anchor-icon" aria-hidden="true"
+              ><svg
+                focusable="false"
+                aria-hidden="true"
+                class="icon-link svelte-1y7sq6j"
+              >
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                />
-              </svg>
-            </span>
-            <span class="visuallyhidden">Anchor link</span>
-          </a>
+                ></path></svg
+            ></span>
+            <span class="visuallyhidden">Anchor link</span></a
+          >
         </h2>
         <a
-          href="https://github.com/CivicActions/openacr/blob/main/openacr/drupal-10-15.yaml"
-          >https://github.com/CivicActions/openacr/blob/main/openacr/drupal-10-15.yaml</a
+          href="https://github.com/GSA/openacr/blob/main/openacr/drupal-10-16.yaml"
+          target="_blank"
+          >https://github.com/GSA/openacr/blob/main/openacr/drupal-10-16.yaml<span
+            class="visuallyhidden"
+            >(opens in a new window or tab)</span
+          ></a
         >
-        <h2 id="feedback">
+        <h2 id="feedback-download" class="svelte-1y7sq6j">
           Feedback
-          <a href="#feedback" class="header-anchor">
-            <span class="anchor-icon" aria-hidden="true">
-              <svg focusable="false" aria-hidden="true" class="icon-link">
+          <a href="#feedback-download" class="header-anchor svelte-1y7sq6j"
+            ><span class="anchor-icon" aria-hidden="true"
+              ><svg
+                focusable="false"
+                aria-hidden="true"
+                class="icon-link svelte-1y7sq6j"
+              >
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                />
-              </svg>
-            </span>
-            <span class="visuallyhidden">Anchor link</span>
-          </a>
+                ></path></svg
+            ></span>
+            <span class="visuallyhidden">Anchor link</span></a
+          >
         </h2>
-        <a href="https://www.drupal.org/project/issues/drupal"
-          >https://www.drupal.org/project/issues/drupal</a
+        <a href="https://www.drupal.org/project/issues/drupal" target="_blank"
+          >https://www.drupal.org/project/issues/drupal<span
+            class="visuallyhidden"
+            >(opens in a new window or tab)</span
+          ></a
         >
+        <h2 id="related-openacrs-download" class="svelte-1y7sq6j">
+          Related OpenACRs
+          <a
+            href="#related-openacrs-download"
+            class="header-anchor svelte-1y7sq6j"
+            ><span class="anchor-icon" aria-hidden="true"
+              ><svg
+                focusable="false"
+                aria-hidden="true"
+                class="icon-link svelte-1y7sq6j"
+              >
+                <path
+                  d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+                ></path></svg
+            ></span>
+            <span class="visuallyhidden">Anchor link</span></a
+          >
+        </h2>
+        <ul></ul>
       </div>
     </main>
     <footer class="usa-footer usa-footer usa-footer--slim">
       <div class="usa-footer__return-to-top">
-        <div class="grid-container">
-          <a href="#">Return to top</a>
-        </div>
+        <div class="grid-container"><a href="#">Return to top</a></div>
       </div>
       <div class="usa-footer__secondary-section">
         <div class="grid-container">
           <div class="grid-row grid-gap">
             <div class="grid-col">
               <a href="https://github.com/GSA/openacr" target="_blank"
-                >OpenACR<span class="usa-sr-only">
+                >OpenACR<span class="visuallyhidden">
                   (opens in a new window or tab)</span
                 ></a
               >
               is a format maintained by the
               <a href="https://gsa.gov/" target="_blank"
-                >GSA<span class="usa-sr-only">
+                >GSA<span class="visuallyhidden">
                   (opens in a new window or tab)</span
                 ></a
               >. The content is the responsibility of the author.
@@ -3673,7 +4040,7 @@
                 href="https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html"
                 target="_blank"
                 >GNU General Public License v2.0 or later<span
-                  class="usa-sr-only"
+                  class="visuallyhidden"
                 >
                   (opens in a new window or tab)</span
                 ></a

--- a/openacr/drupal-10-16.html
+++ b/openacr/drupal-10-16.html
@@ -1,146 +1,64 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Drupal</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Drupal</title>
+    <script
+      type="text/javascript"
+      charset="utf8"
+      src="uswds/js/uswds-init.min.js"
+    ></script>
+    <link rel="stylesheet" href="uswds/css/uswds.min.css" />
+    <link rel="stylesheet" href="openacr.css" />
+    <link rel="stylesheet" href="custom.css" />
   </head>
-  <body id="openACR">
-    <style>
-      body#openACR {
-        padding-left: 35px;
-      }
-      h2,
-      h3 {
-        position: relative;
-      }
-      h2 a.header-anchor,
-      h3 a.header-anchor {
-        position: absolute;
-        left: -2rem;
-      }
-      h2 a.header-anchor:hover svg,
-      h2 a.header-anchor:focus svg,
-      h2 a.header-anchor:focus-within svg,
-      h3 a.header-anchor:hover svg,
-      h3 a.header-anchor:focus svg,
-      h3 a.header-anchor:focus-within svg {
-        fill: #0000ee;
-        opacity: 1;
-      }
-      h2 a.header-anchor svg,
-      h3 a.header-anchor svg {
-        width: 28px;
-        height: 28px;
-        opacity: 0.3;
-      }
-      @media all and (max-width: 63.99em) {
-        h2 a.header-anchor,
-        h3 a.header-anchor {
-          position: relative;
-          opacity: 1;
-          left: 0;
-          vertical-align: top;
-        }
-      }
-      a.header-anchor {
-        opacity: 0.4;
-        font-size: small;
-        text-decoration: none;
-        position: relative;
-        /* left: 20px; */
-        -webkit-transition: opacity 1s, font-size 1s;
-        -moz-transition: opacity 1s, font-size 1s;
-        -o-transition: opacity 1s, font-size 1s;
-        transition: opacity 1s, font-size 1s;
-      }
-      a.header-anchor:focus,
-      a.header-anchor:hover {
-        text-decoration: underline;
-        font-size: large;
-        opacity: 1;
-      }
-      .visuallyhidden {
-        border: 0;
-        clip: rect(0 0 0 0);
-        clip-path: inset(50%);
-        height: 1px;
-        margin: -1px;
-        overflow: hidden;
-        padding: 0;
-        position: absolute;
-        width: 1px;
-        white-space: nowrap;
-        &.focusable {
-          &:active,
-          &:focus {
-            clip: auto;
-            clip-path: none;
-            height: auto;
-            margin: 0;
-            overflow: visible;
-            position: static;
-            width: auto;
-            white-space: inherit;
-          }
-        }
-      }
-      .applicable-standards-guidelines-table th:nth-child(1) {
-        width: 40%;
-      }
-      .applicable-standards-guidelines-table th:nth-child(2) {
-        width: 60%;
-      }
-      /* If only one level then hide the label. */
-      .component-level-count-1 .component-level-label {
-        display: none;
-      }
-    </style>
+  <body>
+    <script
+      type="text/javascript"
+      charset="utf8"
+      src="uswds/js/uswds.min.js"
+    ></script>
     <main>
       <div class="grid-container">
-        <h1 class="svelte-1nee40z">
+        <h1>
           <span class="evaluation-title">Drupal</span> Accessibility Conformance
           Report
         </h1>
+
         <div class="catalog-section">Based on VPAT® 2.4</div>
+
         <div class="product-section">
-          <h2 id="name-of-product-version-download" class="svelte-1y7sq6j">
+          <h2 id="name-of-product-version">
             Name of Product/Version
-            <a
-              href="#name-of-product-version-download"
-              class="header-anchor svelte-1y7sq6j"
-              ><span class="anchor-icon" aria-hidden="true"
-                ><svg
-                  focusable="false"
-                  aria-hidden="true"
-                  class="icon-link svelte-1y7sq6j"
-                >
+            <a href="#name-of-product-version" class="header-anchor">
+              <span class="anchor-icon" aria-hidden="true">
+                <svg focusable="false" aria-hidden="true" class="icon-link">
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  ></path></svg
-              ></span>
-              <span class="visuallyhidden">Anchor link</span></a
-            >
+                  />
+                </svg>
+              </span>
+              <span class="visuallyhidden">Anchor link</span>
+            </a>
           </h2>
           Drupal 10
         </div>
+
         <div class="report-dates-ver-section">
-          <h2 id="report-date-download" class="svelte-1y7sq6j">
+          <h2 id="report-date">
             Report Dates and Version
-            <a href="#report-date-download" class="header-anchor svelte-1y7sq6j"
-              ><span class="anchor-icon" aria-hidden="true"
-                ><svg
-                  focusable="false"
-                  aria-hidden="true"
-                  class="icon-link svelte-1y7sq6j"
-                >
+            <a href="#report-date" class="header-anchor">
+              <span class="anchor-icon" aria-hidden="true">
+                <svg focusable="false" aria-hidden="true" class="icon-link">
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  ></path></svg
-              ></span>
-              <span class="visuallyhidden">Anchor link</span></a
-            >
+                  />
+                </svg>
+              </span>
+              <span class="visuallyhidden">Anchor link</span>
+            </a>
           </h2>
           <ul>
             <li>Report Date: 2023-05-12</li>
@@ -148,24 +66,20 @@
             <li>Version: drupal-10-16</li>
           </ul>
         </div>
+
         <div class="description-section">
-          <h2 id="product-description-download" class="svelte-1y7sq6j">
+          <h2 id="product-description">
             Product Description
-            <a
-              href="#product-description-download"
-              class="header-anchor svelte-1y7sq6j"
-              ><span class="anchor-icon" aria-hidden="true"
-                ><svg
-                  focusable="false"
-                  aria-hidden="true"
-                  class="icon-link svelte-1y7sq6j"
-                >
+            <a href="#product-description" class="header-anchor">
+              <span class="anchor-icon" aria-hidden="true">
+                <svg focusable="false" aria-hidden="true" class="icon-link">
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  ></path></svg
-              ></span>
-              <span class="visuallyhidden">Anchor link</span></a
-            >
+                  />
+                </svg>
+              </span>
+              <span class="visuallyhidden">Anchor link</span>
+            </a>
           </h2>
           <p>
             Drupal is an open source content management platform supporting a
@@ -173,41 +87,34 @@
             community-driven websites.
           </p>
         </div>
+
         <div id="contact-section">
-          <h2 id="contact-information-download" class="svelte-1y7sq6j">
+          <h2 id="contact-information">
             Contact Information
-            <a
-              href="#contact-information-download"
-              class="header-anchor svelte-1y7sq6j"
-              ><span class="anchor-icon" aria-hidden="true"
-                ><svg
-                  focusable="false"
-                  aria-hidden="true"
-                  class="icon-link svelte-1y7sq6j"
-                >
+            <a href="#contact-information" class="header-anchor">
+              <span class="anchor-icon" aria-hidden="true">
+                <svg focusable="false" aria-hidden="true" class="icon-link">
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  ></path></svg
-              ></span>
-              <span class="visuallyhidden">Anchor link</span></a
-            >
+                  />
+                </svg>
+              </span>
+              <span class="visuallyhidden">Anchor link</span>
+            </a>
           </h2>
           <div class="author-section">
-            <h3 id="author-download" class="svelte-1y7sq6j">
+            <h3 id="author">
               Author Information
-              <a href="#author-download" class="header-anchor svelte-1y7sq6j"
-                ><span class="anchor-icon" aria-hidden="true"
-                  ><svg
-                    focusable="false"
-                    aria-hidden="true"
-                    class="icon-link svelte-1y7sq6j"
-                  >
+              <a href="#author" class="header-anchor">
+                <span class="anchor-icon" aria-hidden="true">
+                  <svg focusable="false" aria-hidden="true" class="icon-link">
                     <path
                       d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                    ></path></svg
-                ></span>
-                <span class="visuallyhidden">Anchor link</span></a
-              >
+                    />
+                  </svg>
+                </span>
+                <span class="visuallyhidden">Anchor link</span>
+              </a>
             </h3>
             <ul>
               <li>Name: Mike Gifford</li>
@@ -217,59 +124,48 @@
               </li>
               <li>
                 Email:
-                <a href="mailto:mike.gifford@civicactions.com" target="_blank"
-                  >mike.gifford@civicactions.com<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
+                <a href="mailto:mike.gifford@civicactions.com"
+                  >mike.gifford@civicactions.com</a
                 >
               </li>
               <li>Phone: (510) 408-7510</li>
               <li>
                 Website:
-                <a href="https://civicactions.com" target="_blank"
-                  >https://civicactions.com<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
-                >
+                <a href="https://civicactions.com">https://civicactions.com</a>
               </li>
             </ul>
           </div>
           <div class="vendor-section">
-            <h3 id="vendor-download" class="svelte-1y7sq6j">
+            <h3 id="vendor">
               Vendor Information
-              <a href="#vendor-download" class="header-anchor svelte-1y7sq6j"
-                ><span class="anchor-icon" aria-hidden="true"
-                  ><svg
-                    focusable="false"
-                    aria-hidden="true"
-                    class="icon-link svelte-1y7sq6j"
-                  >
+              <a href="#vendor" class="header-anchor">
+                <span class="anchor-icon" aria-hidden="true">
+                  <svg focusable="false" aria-hidden="true" class="icon-link">
                     <path
                       d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                    ></path></svg
-                ></span>
-                <span class="visuallyhidden">Anchor link</span></a
-              >
+                    />
+                  </svg>
+                </span>
+                <span class="visuallyhidden">Anchor link</span>
+              </a>
             </h3>
             <ul></ul>
           </div>
         </div>
+
         <div class="notes-section">
-          <h2 id="notes-download" class="svelte-1y7sq6j">
+          <h2 id="notes">
             Notes
-            <a href="#notes-download" class="header-anchor svelte-1y7sq6j"
-              ><span class="anchor-icon" aria-hidden="true"
-                ><svg
-                  focusable="false"
-                  aria-hidden="true"
-                  class="icon-link svelte-1y7sq6j"
-                >
+            <a href="#notes" class="header-anchor">
+              <span class="anchor-icon" aria-hidden="true">
+                <svg focusable="false" aria-hidden="true" class="icon-link">
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  ></path></svg
-              ></span>
-              <span class="visuallyhidden">Anchor link</span></a
-            >
+                  />
+                </svg>
+              </span>
+              <span class="visuallyhidden">Anchor link</span>
+            </a>
           </h2>
           <p>
             Links to the issues identified are included where possible to ensure
@@ -279,24 +175,20 @@
             Drupal community.
           </p>
         </div>
+
         <div class="eval-section">
-          <h2 id="evaluation-methods-download" class="svelte-1y7sq6j">
+          <h2 id="evaluation-methods">
             Evaluation Methods
-            <a
-              href="#evaluation-methods-download"
-              class="header-anchor svelte-1y7sq6j"
-              ><span class="anchor-icon" aria-hidden="true"
-                ><svg
-                  focusable="false"
-                  aria-hidden="true"
-                  class="icon-link svelte-1y7sq6j"
-                >
+            <a href="#evaluation-methods" class="header-anchor">
+              <span class="anchor-icon" aria-hidden="true">
+                <svg focusable="false" aria-hidden="true" class="icon-link">
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  ></path></svg
-              ></span>
-              <span class="visuallyhidden">Anchor link</span></a
-            >
+                  />
+                </svg>
+              </span>
+              <span class="visuallyhidden">Anchor link</span>
+            </a>
           </h2>
           <p>
             Use of automated tools like WAVE and Accessibility Insights. Manual
@@ -305,33 +197,23 @@
             accessibility issue queue.
           </p>
         </div>
+
         <div class="standards-section">
-          <h2
-            id="applicable-standards-guidelines-download"
-            class="svelte-1y7sq6j"
-          >
+          <h2 id="applicable-standards-guidelines">
             Applicable Standards/Guidelines
-            <a
-              href="#applicable-standards-guidelines-download"
-              class="header-anchor svelte-1y7sq6j"
-              ><span class="anchor-icon" aria-hidden="true"
-                ><svg
-                  focusable="false"
-                  aria-hidden="true"
-                  class="icon-link svelte-1y7sq6j"
-                >
+            <a href="#applicable-standards-guidelines" class="header-anchor">
+              <span class="anchor-icon" aria-hidden="true">
+                <svg focusable="false" aria-hidden="true" class="icon-link">
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  ></path></svg
-              ></span>
-              <span class="visuallyhidden">Anchor link</span></a
-            >
+                  />
+                </svg>
+              </span>
+              <span class="visuallyhidden">Anchor link</span>
+            </a>
           </h2>
-          <table
-            class="usa-table applicable-standards-guidelines-table"
-            border="1"
-            style="border-collapse: collapse"
-          >
+
+          <table class="usa-table applicable-standards-guidelines-table">
             <caption>
               This report covers the degree of conformance for the following
               accessibility standard/guidelines:
@@ -347,8 +229,9 @@
                 <td>
                   <a href="https://www.w3.org/TR/WCAG21/" target="_blank"
                     >Web Content Accessibility Guidelines 2.1<span
-                      class="visuallyhidden"
-                      >(opens in a new window or tab)</span
+                      class="usa-sr-only"
+                    >
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -363,22 +246,20 @@
             </tbody>
           </table>
         </div>
+
         <div class="terms-section">
-          <h2 id="terms-download" class="svelte-1y7sq6j">
+          <h2 id="terms">
             Terms
-            <a href="#terms-download" class="header-anchor svelte-1y7sq6j"
-              ><span class="anchor-icon" aria-hidden="true"
-                ><svg
-                  focusable="false"
-                  aria-hidden="true"
-                  class="icon-link svelte-1y7sq6j"
-                >
+            <a href="#terms" class="header-anchor">
+              <span class="anchor-icon" aria-hidden="true">
+                <svg focusable="false" aria-hidden="true" class="icon-link">
                   <path
                     d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                  ></path></svg
-              ></span>
-              <span class="visuallyhidden">Anchor link</span></a
-            >
+                  />
+                </svg>
+              </span>
+              <span class="visuallyhidden">Anchor link</span>
+            </a>
           </h2>
           The terms used in the Conformance Level information are defined as
           follows:
@@ -407,40 +288,35 @@
             </li>
           </ul>
         </div>
-        <h2 id="wcag-2.1-download" class="svelte-1y7sq6j">
+
+        <h2 id="wcag-2.1">
           WCAG 2.1 Report
-          <a href="#wcag-2.1-download" class="header-anchor svelte-1y7sq6j"
-            ><span class="anchor-icon" aria-hidden="true"
-              ><svg
-                focusable="false"
-                aria-hidden="true"
-                class="icon-link svelte-1y7sq6j"
-              >
+          <a href="#wcag-2.1" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                ></path></svg
-            ></span>
-            <span class="visuallyhidden">Anchor link</span></a
-          >
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
         </h2>
-        <h3 id="success_criteria_level_a-download" class="svelte-1y7sq6j">
+
+        <h3 id="success_criteria_level_a">
           Table 1: Success Criteria, Level A
-          <a
-            href="#success_criteria_level_a-download"
-            class="header-anchor svelte-1y7sq6j"
-            ><span class="anchor-icon" aria-hidden="true"
-              ><svg
-                focusable="false"
-                aria-hidden="true"
-                class="icon-link svelte-1y7sq6j"
-              >
+          <a href="#success_criteria_level_a" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                ></path></svg
-            ></span>
-            <span class="visuallyhidden">Anchor link</span></a
-          >
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
         </h3>
+
         <div id="success_criteria_level_a-notes" class="chapter-notes-section">
           Notes:
           <p>
@@ -455,6 +331,7 @@
             WCAG recommendation.
           </p>
         </div>
+
         <div id="success_criteria_level_a-summary">
           <p>
             Conformance to the 30 criteria listed below is distributed as
@@ -467,31 +344,29 @@
             <li>68 not applicable</li>
           </ul>
         </div>
-        <table
-          class="usa-table svelte-1an8xyy"
-          border="1"
-          style="border-collapse: collapse"
-        >
-          <thead class="svelte-1an8xyy">
-            <tr class="svelte-1an8xyy">
-              <th class="svelte-1an8xyy">Criteria</th>
-              <th class="svelte-1an8xyy">Conformance Level</th>
-              <th class="svelte-1an8xyy">Remarks and Explanations</th>
+
+        <table class="usa-table">
+          <thead>
+            <tr>
+              <th>Criteria</th>
+              <th>Conformance Level</th>
+              <th>Remarks and Explanations</th>
             </tr>
           </thead>
           <tbody>
-            <tr class="result-row svelte-cn2gpq" id="non-text-content-download">
-              <td class="svelte-cn2gpq">
+            <tr id="1.1.1">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#non-text-content"
                   target="_blank"
-                  >1.1.1 Non-text Content<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.1.1 Non-text Content<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -518,8 +393,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -566,22 +441,21 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="audio-only-and-video-only-prerecorded-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.2.1">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#audio-only-and-video-only-prerecorded"
                   target="_blank"
-                  >1.2.1 Audio-only and Video-only (Prerecorded)<span
-                    class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.2.1 Audio-only and Video-only (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -608,8 +482,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -631,21 +505,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="captions-prerecorded-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.2.2">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#captions-prerecorded"
                   target="_blank"
-                  >1.2.2 Captions (Prerecorded)<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.2.2 Captions (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -672,8 +544,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -697,22 +569,20 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="audio-description-or-media-alternative-prerecorded-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.2.3">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#audio-description-or-media-alternative-prerecorded"
                   target="_blank"
-                  >1.2.3 Audio Description or Media Alternative
-                  (Prerecorded)<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.2.3 Audio Description or Media Alternative
+                  (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -739,8 +609,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -763,21 +633,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="info-and-relationships-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.3.1">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#info-and-relationships"
                   target="_blank"
-                  >1.3.1 Info and Relationships<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.3.1 Info and Relationships<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -804,8 +672,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -850,21 +718,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="meaningful-sequence-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.3.2">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#meaningful-sequence"
                   target="_blank"
-                  >1.3.2 Meaningful Sequence<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.3.2 Meaningful Sequence<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -891,8 +757,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -915,21 +781,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="sensory-characteristics-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.3.3">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#sensory-characteristics"
                   target="_blank"
-                  >1.3.3 Sensory Characteristics<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.3.3 Sensory Characteristics<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -956,8 +820,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -979,18 +843,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="use-of-color-download">
-              <td class="svelte-cn2gpq">
+            <tr id="1.4.1">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#use-of-color"
                   target="_blank"
-                  >1.4.1 Use of Color<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.4.1 Use of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1017,8 +882,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1058,18 +923,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="audio-control-download">
-              <td class="svelte-cn2gpq">
+            <tr id="1.4.2">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#audio-control"
                   target="_blank"
-                  >1.4.2 Audio Control<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.4.2 Audio Control<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1096,8 +962,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1121,16 +987,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="keyboard-download">
-              <td class="svelte-cn2gpq">
-                <a href="https://www.w3.org/TR/WCAG21/#keyboard" target="_blank"
-                  >2.1.1 Keyboard<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
+            <tr id="2.1.1">
+              <td>
+                <a
+                  href="https://www.w3.org/TR/WCAG21/#keyboard"
+                  target="_blank"
                 >
+                  2.1.1 Keyboard<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1157,8 +1026,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1196,18 +1065,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="no-keyboard-trap-download">
-              <td class="svelte-cn2gpq">
+            <tr id="2.1.2">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#no-keyboard-trap"
                   target="_blank"
-                  >2.1.2 No Keyboard Trap<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.1.2 No Keyboard Trap<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1234,8 +1104,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1267,21 +1137,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="character-key-shortcuts-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="2.1.4">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#character-key-shortcuts"
                   target="_blank"
-                  >2.1.4 Character Key Shortcuts<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.1.4 Character Key Shortcuts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1308,8 +1176,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1325,21 +1193,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="timing-adjustable-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="2.2.1">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#timing-adjustable"
                   target="_blank"
-                  >2.2.1 Timing Adjustable<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.2.1 Timing Adjustable<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1366,8 +1232,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1383,18 +1249,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="pause-stop-hide-download">
-              <td class="svelte-cn2gpq">
+            <tr id="2.2.2">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#pause-stop-hide"
                   target="_blank"
-                  >2.2.2 Pause, Stop, Hide<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.2.2 Pause, Stop, Hide<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1421,8 +1288,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1438,22 +1305,21 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="three-flashes-or-below-threshold-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="2.3.1">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#three-flashes-or-below-threshold"
                   target="_blank"
-                  >2.3.1 Three Flashes or Below Threshold<span
-                    class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.3.1 Three Flashes or Below Threshold<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1480,8 +1346,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1497,18 +1363,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="bypass-blocks-download">
-              <td class="svelte-cn2gpq">
+            <tr id="2.4.1">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#bypass-blocks"
                   target="_blank"
-                  >2.4.1 Bypass Blocks<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.4.1 Bypass Blocks<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1535,8 +1402,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1552,18 +1419,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="page-titled-download">
-              <td class="svelte-cn2gpq">
+            <tr id="2.4.2">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#page-titled"
                   target="_blank"
-                  >2.4.2 Page Titled<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.4.2 Page Titled<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1590,8 +1458,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1624,18 +1492,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="focus-order-download">
-              <td class="svelte-cn2gpq">
+            <tr id="2.4.3">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#focus-order"
                   target="_blank"
-                  >2.4.3 Focus Order<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.4.3 Focus Order<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1662,8 +1531,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1701,21 +1570,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="link-purpose-in-context-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="2.4.4">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#link-purpose-in-context"
                   target="_blank"
-                  >2.4.4 Link Purpose (In Context)<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.4.4 Link Purpose (In Context)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1742,8 +1609,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1779,18 +1646,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="pointer-gestures-download">
-              <td class="svelte-cn2gpq">
+            <tr id="2.5.1">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#pointer-gestures"
                   target="_blank"
-                  >2.5.1 Pointer Gestures<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.5.1 Pointer Gestures<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1817,8 +1685,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1834,21 +1702,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="pointer-cancellation-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="2.5.2">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#pointer-cancellation"
                   target="_blank"
-                  >2.5.2 Pointer Cancellation<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.5.2 Pointer Cancellation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1875,8 +1741,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1912,18 +1778,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="label-in-name-download">
-              <td class="svelte-cn2gpq">
+            <tr id="2.5.3">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#label-in-name"
                   target="_blank"
-                  >2.5.3 Label in Name<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.5.3 Label in Name<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1950,8 +1817,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -1967,18 +1834,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="motion-actuation-download">
-              <td class="svelte-cn2gpq">
+            <tr id="2.5.4">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#motion-actuation"
                   target="_blank"
-                  >2.5.4 Motion Actuation<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.5.4 Motion Actuation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2005,8 +1873,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2022,18 +1890,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="language-of-page-download">
-              <td class="svelte-cn2gpq">
+            <tr id="3.1.1">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#language-of-page"
                   target="_blank"
-                  >3.1.1 Language of Page<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  3.1.1 Language of Page<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2060,8 +1929,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2077,16 +1946,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="on-focus-download">
-              <td class="svelte-cn2gpq">
-                <a href="https://www.w3.org/TR/WCAG21/#on-focus" target="_blank"
-                  >3.2.1 On Focus<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
+            <tr id="3.2.1">
+              <td>
+                <a
+                  href="https://www.w3.org/TR/WCAG21/#on-focus"
+                  target="_blank"
                 >
+                  3.2.1 On Focus<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2113,8 +1985,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2136,16 +2008,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="on-input-download">
-              <td class="svelte-cn2gpq">
-                <a href="https://www.w3.org/TR/WCAG21/#on-input" target="_blank"
-                  >3.2.2 On Input<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
+            <tr id="3.2.2">
+              <td>
+                <a
+                  href="https://www.w3.org/TR/WCAG21/#on-input"
+                  target="_blank"
                 >
+                  3.2.2 On Input<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2172,8 +2047,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2195,21 +2070,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="error-identification-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="3.3.1">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#error-identification"
                   target="_blank"
-                  >3.3.1 Error Identification<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  3.3.1 Error Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2236,8 +2109,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2273,21 +2146,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="labels-or-instructions-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="3.3.2">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#labels-or-instructions"
                   target="_blank"
-                  >3.3.2 Labels or Instructions<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  3.3.2 Labels or Instructions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2314,8 +2185,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2353,16 +2224,16 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="parsing-download">
-              <td class="svelte-cn2gpq">
-                <a href="https://www.w3.org/TR/WCAG21/#parsing" target="_blank"
-                  >4.1.1 Parsing<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
-                >
+            <tr id="4.1.1">
+              <td>
+                <a href="https://www.w3.org/TR/WCAG21/#parsing" target="_blank">
+                  4.1.1 Parsing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2389,8 +2260,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2422,18 +2293,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="name-role-value-download">
-              <td class="svelte-cn2gpq">
+            <tr id="4.1.2">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#name-role-value"
                   target="_blank"
-                  >4.1.2 Name, Role, Value<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  4.1.2 Name, Role, Value<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2460,8 +2332,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2498,24 +2370,21 @@
             </tr>
           </tbody>
         </table>
-        <h3 id="success_criteria_level_aa-download" class="svelte-1y7sq6j">
+
+        <h3 id="success_criteria_level_aa">
           Table 2: Success Criteria, Level AA
-          <a
-            href="#success_criteria_level_aa-download"
-            class="header-anchor svelte-1y7sq6j"
-            ><span class="anchor-icon" aria-hidden="true"
-              ><svg
-                focusable="false"
-                aria-hidden="true"
-                class="icon-link svelte-1y7sq6j"
-              >
+          <a href="#success_criteria_level_aa" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                ></path></svg
-            ></span>
-            <span class="visuallyhidden">Anchor link</span></a
-          >
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
         </h3>
+
         <div id="success_criteria_level_aa-summary">
           <p>
             Conformance to the 20 criteria listed below is distributed as
@@ -2528,31 +2397,29 @@
             <li>40 not applicable</li>
           </ul>
         </div>
-        <table
-          class="usa-table svelte-1an8xyy"
-          border="1"
-          style="border-collapse: collapse"
-        >
-          <thead class="svelte-1an8xyy">
-            <tr class="svelte-1an8xyy">
-              <th class="svelte-1an8xyy">Criteria</th>
-              <th class="svelte-1an8xyy">Conformance Level</th>
-              <th class="svelte-1an8xyy">Remarks and Explanations</th>
+
+        <table class="usa-table">
+          <thead>
+            <tr>
+              <th>Criteria</th>
+              <th>Conformance Level</th>
+              <th>Remarks and Explanations</th>
             </tr>
           </thead>
           <tbody>
-            <tr class="result-row svelte-cn2gpq" id="captions-live-download">
-              <td class="svelte-cn2gpq">
+            <tr id="1.2.4">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#captions-live"
                   target="_blank"
-                  >1.2.4 Captions (Live)<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.2.4 Captions (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2579,8 +2446,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2596,22 +2463,21 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="audio-description-prerecorded-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.2.5">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#audio-description-prerecorded"
                   target="_blank"
-                  >1.2.5 Audio Description (Prerecorded)<span
-                    class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.2.5 Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2638,8 +2504,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2662,18 +2528,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="orientation-download">
-              <td class="svelte-cn2gpq">
+            <tr id="1.3.4">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#orientation"
                   target="_blank"
-                  >1.3.4 Orientation<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.3.4 Orientation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2700,8 +2567,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2717,21 +2584,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="identify-input-purpose-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.3.5">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#identify-input-purpose"
                   target="_blank"
-                  >1.3.5 Identify Input Purpose<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.3.5 Identify Input Purpose<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2758,8 +2623,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2775,21 +2640,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="visual-audio-contrast-contrast-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.4.3">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-contrast"
                   target="_blank"
-                  >1.4.3 Contrast (Minimum)<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.4.3 Contrast (Minimum)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2816,8 +2679,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2853,21 +2716,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="visual-audio-contrast-scale-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.4.4">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-scale"
                   target="_blank"
-                  >1.4.4 Resize text<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.4.4 Resize text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2894,8 +2755,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2926,21 +2787,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="visual-audio-contrast-text-presentation-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.4.5">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-text-presentation"
                   target="_blank"
-                  >1.4.5 Images of Text<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.4.5 Images of Text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2967,8 +2826,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -2988,16 +2847,16 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="reflow-download">
-              <td class="svelte-cn2gpq">
-                <a href="https://www.w3.org/TR/WCAG21/#reflow" target="_blank"
-                  >1.4.10 Reflow<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
-                >
+            <tr id="1.4.10">
+              <td>
+                <a href="https://www.w3.org/TR/WCAG21/#reflow" target="_blank">
+                  1.4.10 Reflow<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3024,8 +2883,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3061,21 +2920,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="non-text-contrast-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.4.11">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#non-text-contrast"
                   target="_blank"
-                  >1.4.11 Non-text Contrast<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.4.11 Non-text Contrast<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3102,8 +2959,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3141,18 +2998,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="text-spacing-download">
-              <td class="svelte-cn2gpq">
+            <tr id="1.4.12">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#text-spacing"
                   target="_blank"
-                  >1.4.12 Text Spacing<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.4.12 Text Spacing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3179,8 +3037,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3210,21 +3068,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="content-on-hover-or-focus-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="1.4.13">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus"
                   target="_blank"
-                  >1.4.13 Content on Hover or Focus<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  1.4.13 Content on Hover or Focus<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3251,8 +3107,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3268,18 +3124,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="multiple-ways-download">
-              <td class="svelte-cn2gpq">
+            <tr id="2.4.5">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#multiple-ways"
                   target="_blank"
-                  >2.4.5 Multiple Ways<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.4.5 Multiple Ways<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3306,8 +3163,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3329,21 +3186,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="headings-and-labels-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="2.4.6">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#headings-and-labels"
                   target="_blank"
-                  >2.4.6 Headings and Labels<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.4.6 Headings and Labels<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3370,8 +3225,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3406,18 +3261,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="focus-visible-download">
-              <td class="svelte-cn2gpq">
+            <tr id="2.4.7">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#focus-visible"
                   target="_blank"
-                  >2.4.7 Focus Visible<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  2.4.7 Focus Visible<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3444,8 +3300,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3481,21 +3337,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="language-of-parts-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="3.1.2">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#language-of-parts"
                   target="_blank"
-                  >3.1.2 Language of Parts<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  3.1.2 Language of Parts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3522,8 +3376,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3563,21 +3417,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="consistent-navigation-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="3.2.3">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#consistent-navigation"
                   target="_blank"
-                  >3.2.3 Consistent Navigation<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  3.2.3 Consistent Navigation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3604,8 +3456,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3640,21 +3492,19 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="consistent-identification-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="3.2.4">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#consistent-identification"
                   target="_blank"
-                  >3.2.4 Consistent Identification<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  3.2.4 Consistent Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-3 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-3">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3675,8 +3525,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-3 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-3">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3698,18 +3548,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="error-suggestion-download">
-              <td class="svelte-cn2gpq">
+            <tr id="3.3.3">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#error-suggestion"
                   target="_blank"
-                  >3.3.3 Error Suggestion<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  3.3.3 Error Suggestion<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3736,8 +3587,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3759,22 +3610,21 @@
                 </ul>
               </td>
             </tr>
-            <tr
-              class="result-row svelte-cn2gpq"
-              id="error-prevention-legal-financial-data-download"
-            >
-              <td class="svelte-cn2gpq">
+            <tr id="3.3.4">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#error-prevention-legal-financial-data"
                   target="_blank"
-                  >3.3.4 Error Prevention (Legal, Financial, Data)<span
-                    class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  3.3.4 Error Prevention (Legal, Financial, Data)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3801,8 +3651,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3821,18 +3671,19 @@
                 </ul>
               </td>
             </tr>
-            <tr class="result-row svelte-cn2gpq" id="status-messages-download">
-              <td class="svelte-cn2gpq">
+            <tr id="4.1.3">
+              <td>
                 <a
                   href="https://www.w3.org/TR/WCAG21/#status-messages"
                   target="_blank"
-                  >4.1.3 Status Messages<span class="visuallyhidden"
-                    >(opens in a new window or tab)</span
-                  ></a
                 >
+                  4.1.3 Status Messages<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
+                  >
+                </a>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3859,8 +3710,8 @@
                   </li>
                 </ul>
               </td>
-              <td class="svelte-cn2gpq">
-                <ul class="component-level-count-4 svelte-cn2gpq">
+              <td>
+                <ul class="component-level-count-4">
                   <li>
                     <span class="component-level-label"
                       ><strong>Web</strong>:
@@ -3895,24 +3746,21 @@
             </tr>
           </tbody>
         </table>
-        <h3 id="success_criteria_level_aaa-download" class="svelte-1y7sq6j">
+
+        <h3 id="success_criteria_level_aaa">
           Table 3: Success Criteria, Level AAA
-          <a
-            href="#success_criteria_level_aaa-download"
-            class="header-anchor svelte-1y7sq6j"
-            ><span class="anchor-icon" aria-hidden="true"
-              ><svg
-                focusable="false"
-                aria-hidden="true"
-                class="icon-link svelte-1y7sq6j"
-              >
+          <a href="#success_criteria_level_aaa" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                ></path></svg
-            ></span>
-            <span class="visuallyhidden">Anchor link</span></a
-          >
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
         </h3>
+
         <div
           id="success_criteria_level_aaa-notes"
           class="chapter-notes-section"
@@ -3922,23 +3770,19 @@
             Where possible the Drupal community strives to exceed AA compliance.
           </p>
         </div>
-        <h2 id="legal-disclaimer-download" class="svelte-1y7sq6j">
+
+        <h2 id="legal-disclaimer">
           Legal Disclaimer
-          <a
-            href="#legal-disclaimer-download"
-            class="header-anchor svelte-1y7sq6j"
-            ><span class="anchor-icon" aria-hidden="true"
-              ><svg
-                focusable="false"
-                aria-hidden="true"
-                class="icon-link svelte-1y7sq6j"
-              >
+          <a href="#legal-disclaimer" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                ></path></svg
-            ></span>
-            <span class="visuallyhidden">Anchor link</span></a
-          >
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
         </h2>
         <p>
           The information herein is provided in good faith based on the analysis
@@ -3947,89 +3791,77 @@
           accessibility errors or conformance claim errors for re-evaluation and
           correction, if necessary.
         </p>
-        <h2 id="repository-download" class="svelte-1y7sq6j">
+
+        <h2 id="repository">
           Repository
-          <a href="#repository-download" class="header-anchor svelte-1y7sq6j"
-            ><span class="anchor-icon" aria-hidden="true"
-              ><svg
-                focusable="false"
-                aria-hidden="true"
-                class="icon-link svelte-1y7sq6j"
-              >
+          <a href="#repository" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                ></path></svg
-            ></span>
-            <span class="visuallyhidden">Anchor link</span></a
-          >
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
         </h2>
         <a
-          href="https://github.com/GSA/openacr/blob/main/openacr/drupal-10-16.yaml"
-          target="_blank"
-          >https://github.com/GSA/openacr/blob/main/openacr/drupal-10-16.yaml<span
-            class="visuallyhidden"
-            >(opens in a new window or tab)</span
-          ></a
+          href="https://github.com/CivicActions/openacr/blob/main/openacr/drupal-10-16.yaml"
+          >https://github.com/CivicActions/openacr/blob/main/openacr/drupal-10-16.yaml</a
         >
-        <h2 id="feedback-download" class="svelte-1y7sq6j">
+        <h2 id="feedback">
           Feedback
-          <a href="#feedback-download" class="header-anchor svelte-1y7sq6j"
-            ><span class="anchor-icon" aria-hidden="true"
-              ><svg
-                focusable="false"
-                aria-hidden="true"
-                class="icon-link svelte-1y7sq6j"
-              >
+          <a href="#feedback" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                ></path></svg
-            ></span>
-            <span class="visuallyhidden">Anchor link</span></a
-          >
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
         </h2>
-        <a href="https://www.drupal.org/project/issues/drupal" target="_blank"
-          >https://www.drupal.org/project/issues/drupal<span
-            class="visuallyhidden"
-            >(opens in a new window or tab)</span
-          ></a
+        <a href="https://www.drupal.org/project/issues/drupal"
+          >https://www.drupal.org/project/issues/drupal</a
         >
-        <h2 id="related-openacrs-download" class="svelte-1y7sq6j">
+
+        <h2 id="related-openacrs">
           Related OpenACRs
-          <a
-            href="#related-openacrs-download"
-            class="header-anchor svelte-1y7sq6j"
-            ><span class="anchor-icon" aria-hidden="true"
-              ><svg
-                focusable="false"
-                aria-hidden="true"
-                class="icon-link svelte-1y7sq6j"
-              >
+          <a href="#related-openacrs" class="header-anchor">
+            <span class="anchor-icon" aria-hidden="true">
+              <svg focusable="false" aria-hidden="true" class="icon-link">
                 <path
                   d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
-                ></path></svg
-            ></span>
-            <span class="visuallyhidden">Anchor link</span></a
-          >
+                />
+              </svg>
+            </span>
+            <span class="visuallyhidden">Anchor link</span>
+          </a>
         </h2>
-        <ul></ul>
+        <ul>
+          <li><a href=""> (secondary)</a></li>
+        </ul>
       </div>
     </main>
     <footer class="usa-footer usa-footer usa-footer--slim">
       <div class="usa-footer__return-to-top">
-        <div class="grid-container"><a href="#">Return to top</a></div>
+        <div class="grid-container">
+          <a href="#">Return to top</a>
+        </div>
       </div>
       <div class="usa-footer__secondary-section">
         <div class="grid-container">
           <div class="grid-row grid-gap">
             <div class="grid-col">
               <a href="https://github.com/GSA/openacr" target="_blank"
-                >OpenACR<span class="visuallyhidden">
+                >OpenACR<span class="usa-sr-only">
                   (opens in a new window or tab)</span
                 ></a
               >
               is a format maintained by the
               <a href="https://gsa.gov/" target="_blank"
-                >GSA<span class="visuallyhidden">
+                >GSA<span class="usa-sr-only">
                   (opens in a new window or tab)</span
                 ></a
               >. The content is the responsibility of the author.
@@ -4040,7 +3872,7 @@
                 href="https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html"
                 target="_blank"
                 >GNU General Public License v2.0 or later<span
-                  class="visuallyhidden"
+                  class="usa-sr-only"
                 >
                   (opens in a new window or tab)</span
                 ></a

--- a/openacr/drupal-10-16.yaml
+++ b/openacr/drupal-10-16.yaml
@@ -29,7 +29,7 @@ legal_disclaimer: >-
   web application at the time of the review and does not represent a
   legally-binding claim. Please contact us to report any accessibility errors or
   conformance claim errors for re-evaluation and correction, if necessary.
-repository: "https://github.com/GSA/openacr/blob/main/openacr/drupal-10-16.yaml"
+repository: "https://github.com/CivicActions/openacr/blob/main/openacr/drupal-10-16.yaml"
 feedback: "https://www.drupal.org/project/issues/drupal"
 license: GPL-2.0-or-later
 related_openacrs:

--- a/openacr/drupal-10-16.yaml
+++ b/openacr/drupal-10-16.yaml
@@ -11,10 +11,10 @@ author:
   address: "3527 Mt Diablo Blvd, Unit 269, Lafayette, CA 94549"
   email: mike.gifford@civicactions.com
   phone: (510) 408-7510
-  website: "https://civicactions.com/"
+  website: "https://civicactions.com"
 report_date: "2023-05-12"
-last_modified_date: "2023-05-16"
-version: 15
+last_modified_date: "2023-06-19"
+version: 16
 notes: >-
   Links to the issues identified are included where possible to ensure that this
   is a living document where outstanding issues are regularly reviewed for
@@ -29,10 +29,12 @@ legal_disclaimer: >-
   web application at the time of the review and does not represent a
   legally-binding claim. Please contact us to report any accessibility errors or
   conformance claim errors for re-evaluation and correction, if necessary.
-repository: "https://github.com/CivicActions/openacr/blob/main/openacr/drupal-10-15.yaml"
+repository: "https://github.com/GSA/openacr/blob/main/openacr/drupal-10-16.yaml"
 feedback: "https://www.drupal.org/project/issues/drupal"
 license: GPL-2.0-or-later
-related_openacrs: []
+related_openacrs:
+  - url: ""
+    type: secondary
 chapters:
   success_criteria_level_a:
     notes: >-
@@ -49,23 +51,23 @@ chapters:
         components:
           - name: web
             adherence:
-              level: supports
+              level: partially-supports
               notes: >-
-                Drupal core has no outstanding user barriers. There are
-                improvements in the [outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111)
-                which relate to decorative and the password strength
-                indicator.
+                There are minor barriers which may present themselves to users.
+                There are improvements in the [outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111)
+                which relate to decorative images and the password strength
+                indicator.  Status messages should be clearly marked as
+                decorative. Most of the issues are tied to the administration
+                interface.
 
 
-                All open WCAG 1.1.1 issues:  3232414, 2514218, 3272325, 3230231,
-                3275397, 3087535, 3319601
+                All open WCAG 1.1.1 issue(s): 2921627, 3083994, 3232414,
+                2514218, 3272325, 3230231, 3275397, 3087535, 3319601
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: >-
-                Some non-textual content in the documentation does not provide a
-                textual alternative.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -82,7 +84,7 @@ chapters:
 
 
                 Alternative text is required for images by default. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111)
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111)
                 relate to thumbnail images, management of decorative images, and
                 messages icons.
       - num: 1.2.1
@@ -96,7 +98,7 @@ chapters:
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: This is not explicitly defined in the documentation.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -114,8 +116,7 @@ chapters:
               level: not-applicable
               notes: >-
                 The file module in Core lets authors upload audio and video
-                content, and output  and  elements and does not support
-                captions.
+                content, and output and elements and does not support captions.
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -142,9 +143,7 @@ chapters:
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: >-
-                There is no documentation on how to properly convey pre-recorded
-                audio descriptions.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -163,16 +162,17 @@ chapters:
               level: partially-supports
               notes: >-
                 There are barriers in the [outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag111)
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag131)
                 ARIA landmarks and roles. There are also a number of errors tied
-                to forms (fieldsets, dates, radios &amp; checkboxes). There is
-                also more work needed to provide better semantics for Voice
-                Control and support for Windows High Contrast mode.
+                to forms (fieldsets, dates, radios &amp; checkboxes). More work
+                is needed to provide better semantics for Voice Control and
+                support for Windows High Contrast mode.
 
 
-                All open WCAG 1.3.1 issues: 3081500, 2951317, 3098857, 3347326,
-                3290899, 3171726, 2951714, 3144948, 3078334, 2942404, 3190536,
-                3301868, 3171728, 3194669, 3200642, 3206290, 3127469.
+                All open WCAG 1.3.1 issue(s): 3182458, 3037726, 3037730,
+                3037733, 3037725, 3037625, 2921627, 2937640, 3037446, 3081500,
+                2951317, 3098857, 3347326, 3290899, 3171726, 2951714, 3144948,
+                3078334, 2942404, 3190536, 3301868, 3171728, 3194669, 3200642.
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -190,7 +190,8 @@ chapters:
                 issues are listed in the Web section. There are also
                 accessibility concerns with the vertical tabs and dashboards
                 available to users. Menu blocks are not getting the correct ID
-                in some instances.
+                in some instances. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag131).
       - num: 1.3.2
         components:
           - name: web
@@ -202,7 +203,7 @@ chapters:
                 for bidirectional navigation.
           - name: electronic-docs
             adherence:
-              level: supports
+              level: not-applicable
               notes: ""
           - name: software
             adherence:
@@ -240,10 +241,16 @@ chapters:
         components:
           - name: web
             adherence:
-              level: supports
+              level: partially-supports
               notes: >-
-                Color is not used without text and often symbols to convey
-                meaning.
+                Color is generally not used without text and often symbols to
+                convey meaning. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag141)
+                are mostly tied to authoring tools, but table drag components
+                may also be exposed to an unauthorized user.
+
+
+                All open WCAG 1.4.1 issue(s): 3097907, 3171726, 3059168, 867830
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -259,17 +266,17 @@ chapters:
                 In general, the admin theme is very accessible. Color contrast
                 can be improved with the star image, the toolbar tray, table
                 drag, column severity and unpublished articles. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag141).
-
-
-                All open WCAG 1.4.1 issues: 3097907, 3171726, 3281601, 3059168,
-                867830.
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag141)
+                also include the active toolbar tray, and the admin status
+                report pages.
       - num: 1.4.2
         components:
           - name: web
             adherence:
               level: not-applicable
-              notes: ""
+              notes: >-
+                The file module in Core lets authors upload audio and video
+                content, and output and elements and does not support captions.
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -281,7 +288,9 @@ chapters:
           - name: authoring-tool
             adherence:
               level: not-applicable
-              notes: ""
+              notes: >-
+                The file module in Core lets authors upload audio and video
+                content, and output and elements and does not support captions.
       - num: 2.1.1
         components:
           - name: web
@@ -291,11 +300,14 @@ chapters:
                 Generally, users and authors can interact with Drupal Core with
                 the keyboard and without specific timings for individual
                 keystrokes. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211)
-                with tooltips and the header menu.
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211)
+                with tooltips and the header menu. There are also legacy issues
+                with jQuery UI &amp; header menus. Items like datepickers can
+                also be exposed to users.
 
 
-                All open WCAG 2.1.1 issues:  2933984, 3210434
+                All open WCAG 2.1.1 issue(s):  3085811, 3229647, 3081515,
+                2991686, 2911932, 3210434, 3038336, 2933984, 2852702
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -308,16 +320,22 @@ chapters:
             adherence:
               level: partially-supports
               notes: >-
-                See remarks in Web section. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211).
+                Issues with the toolbar buttons, datepicker, contextual links,
+                and tooltips. Also see remarks in Web section. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag211).
       - num: 2.1.2
         components:
           - name: web
             adherence:
               level: supports
               notes: >-
-                Focus can be moved away from that component using only a
-                keyboard interface.
+                Users can move focus away from that component using only a
+                keyboard interface. There is a known problem with the admin
+                interface.  [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag212).
+
+
+                All open WCAG 2.1.2 issue(s):  2627788
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -330,8 +348,9 @@ chapters:
             adherence:
               level: supports
               notes: >-
-                Focus can be moved away from that component using only a
-                keyboard interface.
+                There is a known issue with focus states on text field AJAX
+                calls.  [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag212).
       - num: 2.1.4
         components:
           - name: web
@@ -413,7 +432,7 @@ chapters:
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: Skip links are provided.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -426,60 +445,15 @@ chapters:
         components:
           - name: web
             adherence:
-              level: supports
-              notes: "Pages are titled correctly. "
-          - name: electronic-docs
-            adherence:
-              level: not-applicable
-              notes: ""
-          - name: software
-            adherence:
-              level: not-applicable
-              notes: ""
-          - name: authoring-tool
-            adherence:
-              level: supports
+              level: partially-supports
               notes: >-
-                Generally, pages are titled correctly. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242)
-                with a regression in how fields are displayed in editing content
-                types.
+                Pages are titled for users correctly. There is an outstanding
+                issue for authors.  [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242)
+                are tied to pagination.
 
 
-                All open WCAG 2.4.2 issues:  2514218
-      - num: 2.4.3
-        components:
-          - name: web
-            adherence:
-              level: supports
-              notes: >-
-                Focusable components receive focus in an order that preserves
-                meaning and operability.
-          - name: electronic-docs
-            adherence:
-              level: not-applicable
-              notes: >-
-                Focusable components receive focus in an order that preserves
-                meaning and operability.
-          - name: software
-            adherence:
-              level: not-applicable
-              notes: ""
-          - name: authoring-tool
-            adherence:
-              level: supports
-              notes: >-
-                Focusable components receive focus in an order that preserves
-                meaning and operability.
-      - num: 2.4.4
-        components:
-          - name: web
-            adherence:
-              level: supports
-              notes: >-
-                Careful attention has been paid to ensure that automated "Read
-                More" links are available in a way that is available with
-                contextual information for screen readers.
+                All open WCAG 2.1.2 issue(s):  2514218, 2509716
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -492,19 +466,24 @@ chapters:
             adherence:
               level: partially-supports
               notes: >-
-                Generally very well-supported. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242)
-                with truncation of the path alias and duplicate links on edit
-                content page.
-
-
-                All open WCAG 2.4.2 issues: 3351638, 2852898
-      - num: 2.5.1
+                Generally, pages are titled correctly. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag242)
+                with a regression in how fields are displayed in editing content
+                types.
+      - num: 2.4.3
         components:
           - name: web
             adherence:
-              level: supports
-              notes: "No known challenges with pointer gestures. "
+              level: partially-supports
+              notes: >-
+                Generally, focusable components receive focus in an order that
+                preserves meaning and operability. Most of these issues are tied
+                to the administration interface. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag243).
+
+
+                All open WCAG 2.1.2 issue(s):  3019849, 3042107, 3047730,
+                2973114, 2925295, 3273086
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -515,14 +494,75 @@ chapters:
               notes: ""
           - name: authoring-tool
             adherence:
+              level: partially-supports
+              notes: >-
+                Generally, focusable components receive focus in an order that
+                preserves meaning and operability. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag243).
+                Some elements of the authoring interface to don't return the
+                focus where an editor should expect it to. There are elements
+                with table drag and Layout Builder which should be addressed.
+      - num: 2.4.4
+        components:
+          - name: web
+            adherence:
+              level: partially-supports
+              notes: >-
+                Careful attention has been paid to ensure that automated "Read
+                More" links are available in a way that is available with
+                contextual information for screen readers. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag244)
+                can be tied to user comments.
+
+
+                All open WCAG 2.4.4 issue(s): 2922435, 3351638, 2852898
+          - name: electronic-docs
+            adherence:
               level: not-applicable
+              notes: ""
+          - name: software
+            adherence:
+              level: not-applicable
+              notes: ""
+          - name: authoring-tool
+            adherence:
+              level: partially-supports
+              notes: >+
+                Generally very well-supported. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag244)
+                with truncation of the path alias and duplicate links on edit
+                content page.
+
+      - num: 2.5.1
+        components:
+          - name: web
+            adherence:
+              level: supports
+              notes: "Pointer gestures are generally very good. "
+          - name: electronic-docs
+            adherence:
+              level: not-applicable
+              notes: ""
+          - name: software
+            adherence:
+              level: not-applicable
+              notes: ""
+          - name: authoring-tool
+            adherence:
+              level: supports
               notes: "No known challenges with pointer gestures. "
       - num: 2.5.2
         components:
           - name: web
             adherence:
               level: supports
-              notes: "No known problems for users with pointer cancellation. "
+              notes: >-
+                No known problems for users with pointer cancellation for
+                users.  [Outstanding
+                issue(s)](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag252).
+
+
+                All open WCAG 2.5.2 issue(s): 2616184, 2968637, 2960840, 2958654
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -534,15 +574,13 @@ chapters:
           - name: authoring-tool
             adherence:
               level: partially-supports
-              notes: >-
+              notes: >+
                 The Drupal ajax framework uses 'mousedown' to capture the click.
                 [Outstanding
-                issue(s)](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag252)
+                issue(s)](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag252)
                 with truncation of the path alias and duplicate links on edit
                 content page.
 
-
-                All open WCAG 2.5.2 issue(s): 2616184
       - num: 2.5.3
         components:
           - name: web
@@ -588,7 +626,7 @@ chapters:
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: Page language is defined semantically on every page.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -596,12 +634,7 @@ chapters:
           - name: authoring-tool
             adherence:
               level: supports
-              notes: >-
-                [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag311).
-
-
-                All open WCAG 3.1.1 issue(s): 3081526
+              notes: Page language is defined semantically on every page.
       - num: 3.2.1
         components:
           - name: web
@@ -613,9 +646,7 @@ chapters:
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: >-
-                Change in the focus state does not initiate a change of context
-                for the user.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -637,9 +668,7 @@ chapters:
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: >-
-                Engaging with the interactive sites does not unexpectedly take
-                control from the users.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -658,14 +687,14 @@ chapters:
               notes: >-
                 The Inline Form Error module needs to be enabled site-wide on
                 installation. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag311).
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag331).
                 Most of these issues are also authoring interface, but there are
                 problems with HTML5 validation, child groupings, required
                 errors, and file uploading.
 
 
-                All open WCAG 3.3.1 issues: 3059955, 1797438, 2848507, 2563173,
-                3087305, 2455933, 3087402, 2847425, 2089703
+                All open WCAG 3.3.1 issue(s): 2848307, 2560467, 2876321,
+                3279596, 3087385, 3059955, 1797438, 2848507, 2563173
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -679,7 +708,7 @@ chapters:
               level: partially-supports
               notes: >-
                 See the Web section as most of these [outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag311)
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag331)
                 are also likely on the user side.
       - num: 3.3.2
         components:
@@ -688,12 +717,14 @@ chapters:
               level: partially-supports
               notes: >-
                 Default forms all include labels. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332)
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332)
                 include a lack of 'aria-describedby' and grouped fields missing
-                labels.
+                labels. There are some exceptions like Views search filter label
+                isn't associated with the input.
 
 
-                All open WCAG 3.3.2 issues: 2998857, 2608212
+                All open WCAG 3.3.2 issue(s): 2608180, 2942037, 3037446,
+                2998857, 2608212
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -709,7 +740,9 @@ chapters:
                 There are a few places where there are problems with labels, but
                 these are odd exceptions. See the Web section for details.
                 [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332).
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag332).
+                There are known issues with the Admin list filter and grouped
+                publishing status messages.
       - num: 4.1.1
         components:
           - name: web
@@ -717,13 +750,15 @@ chapters:
               level: supports
               notes: >-
                 There are no HTML5 errors or warnings that are known to impact
-                assistive technology users.
+                assistive technology users. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag411).
+
+
+                All open WCAG 4.1.1 issue(s):  3174459
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: >-
-                There are no HTML5 errors or warnings that are known to impact
-                assistive technology users.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -734,20 +769,26 @@ chapters:
               notes: >-
                 Generally parsing is very well-supported, but there are a few
                 places where this needs to be improved. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag411).
-
-
-                All open WCAG 4.1.1 issue(s):  3174459
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag411).
+                There is an error identified with fields in articles that has
+                not been independently validated.
       - num: 4.1.2
         components:
           - name: web
             adherence:
-              level: supports
-              notes: Public pages support this criterion.
+              level: partially-supports
+              notes: >-
+                Public pages generally support this criterion.  [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag412).
+                There are issues when Views List is filtered.
+
+
+                All open WCAG 4.1.2 issue(s):  3050559, 2805499, 2913378,
+                2805227, 1096124, 2047089, 3272316, 2942232, 3087313, 2719453
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: Public pages support this criterion.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -758,13 +799,9 @@ chapters:
               notes: >-
                 This is generally well-supported, but there are places where it
                 has been overlooked. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag412).
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag412).
                 There are semantics missing for aria elements in the block,
-                forms, and contextual modules.
-
-
-                All open WCAG 4.1.2 issues:  3083181, 2852724, 3218877, 3028780,
-                1852090, 3085545
+                forms, media, bulk actions and contextual modules.
   success_criteria_level_aa:
     criteria:
       - num: 1.2.4
@@ -784,7 +821,7 @@ chapters:
           - name: authoring-tool
             adherence:
               level: not-applicable
-              notes: ""
+              notes: "This is not a feature supported in Drupal Core. "
       - num: 1.2.5
         components:
           - name: web
@@ -795,10 +832,8 @@ chapters:
                 captions in Core.
           - name: electronic-docs
             adherence:
-              level: does-not-support
-              notes: >-
-                There is no documentation on how to properly convey pre-recorded
-                audio descriptions.
+              level: not-applicable
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -814,38 +849,38 @@ chapters:
         components:
           - name: web
             adherence:
-              level: ""
-              notes: ""
+              level: supports
+              notes: No known problems with orientation.
           - name: electronic-docs
             adherence:
-              level: ""
+              level: not-applicable
               notes: ""
           - name: software
             adherence:
-              level: ""
+              level: not-applicable
               notes: ""
           - name: authoring-tool
             adherence:
-              level: ""
-              notes: ""
+              level: supports
+              notes: No known problems with orientation.
       - num: 1.3.5
         components:
           - name: web
             adherence:
-              level: ""
-              notes: ""
+              level: supports
+              notes: No known problems with input purpose.
           - name: electronic-docs
             adherence:
-              level: ""
+              level: not-applicable
               notes: ""
           - name: software
             adherence:
-              level: ""
+              level: not-applicable
               notes: ""
           - name: authoring-tool
             adherence:
-              level: ""
-              notes: ""
+              level: supports
+              notes: No known problems with input purpose.
       - num: 1.4.3
         components:
           - name: web
@@ -856,15 +891,15 @@ chapters:
                 both user and author interfaces. Asterisks, form labels,
                 disabled form elements, and some dialogs require additional
                 contrast to meet 1.4.3 requirements. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143).
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143).
 
 
-                All open WCAG 1.4.3 issue(s): 3266299, 3040673, 3231744,
-                3200635, 2756483, 2725539, 3076153
+                All open WCAG 1.4.3 issue(s): 3271652, 3318394, 3266299,
+                3040673, 3231744, 3200635, 2756483, 2725539, 3076153
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: The docs have sufficient contrast.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -875,7 +910,7 @@ chapters:
               notes: >-
                 Generally meets requirements. Form elements described in the web
                 section affect both user and author interfaces.  [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143).
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag143).
       - num: 1.4.4
         components:
           - name: web
@@ -884,14 +919,14 @@ chapters:
               notes: >-
                 Generally support with a minor exception with focus outlines.
                 [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144).
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144).
 
 
-                All WCAG 1.4.4 issues: 3068698, 3238618
+                All WCAG 1.4.4 issue(s): 3068698, 3238618, 2384203
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: The docs are accessible up to 200%.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -902,7 +937,7 @@ chapters:
               notes: >-
                 Generally support with some minor exception with limited
                 horizontal space.  [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144).
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag144).
       - num: 1.4.5
         components:
           - name: web
@@ -932,11 +967,11 @@ chapters:
               notes: >-
                 Generally meets. Some issues with long words, responsive tables,
                 resizing menus, and wide screen layout. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410).
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410).
 
 
-                All open WCAG 1.4.10 issues: 3159896, 3177475, 2280035, 3191806,
-                2574721, 3164587.
+                All open WCAG 1.4.10 issue(s): 2313471, 3159896, 3177475,
+                2280035, 3191806, 2574721, 3164587
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -953,7 +988,7 @@ chapters:
                 apply to author interfaces. Generally support with some minor
                 exception with the action links on the modules page.
                 [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410).
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1410).
       - num: 1.4.11
         components:
           - name: web
@@ -962,11 +997,11 @@ chapters:
               notes: >-
                 Generally meets. There are still some images that need to have
                 their contrast increased.  [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411).
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411).
 
 
-                All open WCAG 1.4.11 issues: 3097907, 2910102, 3171726, 3272266,
-                3037742
+                All open WCAG 1.4.11 issue(s): 3273806, 3270130, 3269420,
+                3269342, 3277262, 2990766, 3097907, 2910102, 3171726, 3272266
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -985,13 +1020,19 @@ chapters:
 
 
                 [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411).
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411).
       - num: 1.4.12
         components:
           - name: web
             adherence:
               level: supports
-              notes: ""
+              notes: >-
+                All known related issues are tied to the admin interface.
+                [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1412).
+
+
+                All open WCAG 1.4.12 issue(s): 2919837
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -1006,10 +1047,7 @@ chapters:
               notes: >+
                 Generally supports. There is a known issue with off-canvas
                 dialogs. [Outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1411).
-
-
-                All open WCAG 1.4.12 issues: 2919837
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag1412).
 
       - num: 1.4.13
         components:
@@ -1038,7 +1076,7 @@ chapters:
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: There is more than one way to locate a Web page within the CMS.
+              notes: ""
           - name: authoring-tool
             adherence:
               level: supports
@@ -1052,25 +1090,14 @@ chapters:
           - name: web
             adherence:
               level: supports
-              notes: "Generally there is very good support. "
-          - name: electronic-docs
-            adherence:
-              level: not-applicable
-              notes: ""
-          - name: software
-            adherence:
-              level: not-applicable
-              notes: ""
-          - name: authoring-tool
-            adherence:
-              level: supports
-              notes: Generally good.
-      - num: 2.4.7
-        components:
-          - name: web
-            adherence:
-              level: partially-supports
-              notes: "Focus elements are well established for the front-end. "
+              notes: >-
+                Generally there is very good support. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag246)
+                are for the admin interface.
+
+
+                All open WCAG 2.4.6 issue(s): 3232222, 3277785, 2614950,
+                3333401, 3293673
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -1083,14 +1110,40 @@ chapters:
             adherence:
               level: partially-supports
               notes: >-
-                Generally supports. There is a known [outstanding
-                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag247).
+                Generally good. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag246)
+                are tied to header for the pager template can be outside the
+                document hierarchy order.
+      - num: 2.4.7
+        components:
+          - name: web
+            adherence:
+              level: partially-supports
+              notes: >-
+                Generally there is very good support. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag247).
+
+
+                All open WCAG 2.4.7 issue(s): 2990588, 2822778, 3273054,
+                3200584, 3191727, 3270230, 3091534, 3335411, 3302103, 3273099
+          - name: electronic-docs
+            adherence:
+              level: not-applicable
+              notes: ""
+          - name: software
+            adherence:
+              level: not-applicable
+              notes: ""
+          - name: authoring-tool
+            adherence:
+              level: partially-supports
+              notes: >-
+                Generally supports. There is an [outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag247).
                 A block can be added with layout builder that stops authors from
                 escaping focus. The image style page also has a hidden focus
-                element.
-
-
-                All open WCAG 2.47 issues: 3302103, 3273099
+                element.  There are issues with modal popups in Views and with
+                Toolbar focus styles.
       - num: 3.1.2
         components:
           - name: web
@@ -1098,9 +1151,14 @@ chapters:
               level: partially-supports
               notes: >-
                 Multilingual sites have language switchers with proper
-                semantics. Unfotunately support is lacking for multi-lingual
-                search 2992894 as well as both the Filesystem 3163915 &amp;
-                Views components 2496223.
+                semantics. Unfortunately support is lacking for multilingual
+                search as well as both the Filesystem and Views components.
+                [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag312).
+
+
+                All open WCAG 3.1.2 issue(s): 3300835, 3361370, 3361375,
+                3362791, 2036277, 3300836, 3042984, 82751, 3163915, 3049122
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -1116,30 +1174,41 @@ chapters:
                 Drupal has good support for multilingual content and
                 accessibility. To support the Language of Parts for authors, a
                 button can be added to simplify the process of adding language
-                specific phrases.
+                specific phrases. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag312).
+                There are untranslatable fields in parts of the administration
+                interface that are known.
       - num: 3.2.3
         components:
           - name: web
             adherence:
               level: supports
-              notes: >-
+              notes: >+
                 Drupal's menu structure allows for consistent navigation across
-                the site.
+                the site. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag323).
+                There are some minor issues with mobile in Olivero.
+
+
+                All open WCAG 3.2.3 issue(s): 3129257, 3209129, 3350947,
+                3084554, 2895388
+
           - name: electronic-docs
             adherence:
-              level: supports
-              notes: >-
-                Drupal's menu structure allows for consistent navigation across
-                the site.
+              level: not-applicable
+              notes: ""
           - name: authoring-tool
             adherence:
-              level: supports
+              level: partially-supports
               notes: >-
                 Drupal's menu structure allows for consistent navigation across
-                the site.
+                the site. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag323).
+                There are issues with scrolling with layout builder and with the
+                Modules Uninstall filter.
           - name: software
             adherence:
-              level: ""
+              level: not-applicable
               notes: ""
       - num: 3.2.4
         components:
@@ -1151,10 +1220,8 @@ chapters:
                 identified consistently.
           - name: electronic-docs
             adherence:
-              level: supports
-              notes: >-
-                Components in Drupal that have the same functionality are
-                identified consistently.
+              level: not-applicable
+              notes: ""
           - name: authoring-tool
             adherence:
               level: supports
@@ -1196,7 +1263,7 @@ chapters:
           - name: electronic-docs
             adherence:
               level: not-applicable
-              notes: Documentation could be improved.
+              notes: ""
           - name: software
             adherence:
               level: not-applicable
@@ -1212,7 +1279,13 @@ chapters:
           - name: web
             adherence:
               level: supports
-              notes: "No known problems with status messages. "
+              notes: >-
+                No known problems with status messages. [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag413).
+
+
+                All open WCAG 4.1.3 issue(s): 2973116, 2893663, 3035435,
+                3159933, 2973140
           - name: electronic-docs
             adherence:
               level: not-applicable
@@ -1224,10 +1297,14 @@ chapters:
           - name: authoring-tool
             adherence:
               level: supports
-              notes: "No known problems with status messages. "
+              notes: >-
+                [Outstanding
+                issues](https://www.drupal.org/project/issues/search/drupal?text=&amp;assigned=&amp;submitted=&amp;project_issue_followers=&amp;status%5B%5D=Open&amp;version%5B%5D=any_11.&amp;version%5B%5D=any_10.&amp;issue_tags_op=%3D&amp;issue_tags=wcag413)
+                are known after enabling/disabling a View, with the dropdown
+                buttons, and with progress messages.
     notes: ""
   success_criteria_level_aaa:
-    notes: ""
+    notes: Where possible the Drupal community strives to exceed AA compliance.
     criteria:
       - num: 1.2.6
         components:
@@ -2341,4 +2418,11 @@ chapters:
             adherence:
               level: ""
               notes: ""
+vendor:
+  name: ""
+  company_name: ""
+  address: ""
+  email: ""
+  phone: ""
+  website: ""
 catalog: 2.4-edition-wcag-2.1-en

--- a/openacr/drupal-9-simple.html
+++ b/openacr/drupal-9-simple.html
@@ -109,6 +109,7 @@
 
       table {
         border-collapse: collapse;
+        margin: 10px 0;
       }
       th,
       td {
@@ -448,16 +449,49 @@
         </div>
 
         <div id="success_criteria_level_a-summary">
-          <p>
-            Conformance to the 30 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>57 supported</li>
-            <li>4 partially supported</li>
-            <li>5 not supported</li>
-            <li>34 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 30 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>19</td>
+              <td>19</td>
+              <td>0</td>
+              <td>19</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>2</td>
+              <td>0</td>
+              <td>0</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>2</td>
+              <td>1</td>
+              <td>0</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>2</td>
+              <td>5</td>
+              <td>25</td>
+              <td>2</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2170,16 +2204,49 @@
         </h3>
 
         <div id="success_criteria_level_aa-summary">
-          <p>
-            Conformance to the 20 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>20 supported</li>
-            <li>9 partially supported</li>
-            <li>3 not supported</li>
-            <li>16 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 20 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>5</td>
+              <td>8</td>
+              <td>0</td>
+              <td>7</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>5</td>
+              <td>0</td>
+              <td>0</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>1</td>
+              <td>1</td>
+              <td>0</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>2</td>
+              <td>4</td>
+              <td>10</td>
+              <td>0</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -3162,16 +3229,49 @@
         </div>
 
         <div id="success_criteria_level_aaa-summary">
-          <p>
-            Conformance to the 28 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>7 supported</li>
-            <li>1 partially supported</li>
-            <li>0 not supported</li>
-            <li>14 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 28 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>7</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>1</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>14</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -3973,16 +4073,34 @@
         </div>
 
         <div id="functional_performance_criteria-summary">
-          <p>
-            Conformance to the 9 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>5 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>4 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 9 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>5</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>4</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -4309,16 +4427,34 @@
         </div>
 
         <div id="support_documentation_and_services-summary">
-          <p>
-            Conformance to the 5 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>0 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>4 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 5 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>4</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">

--- a/openacr/drupal-9.html
+++ b/openacr/drupal-9.html
@@ -351,16 +351,49 @@
         </div>
 
         <div id="success_criteria_level_a-summary">
-          <p>
-            Conformance to the 30 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>57 supported</li>
-            <li>4 partially supported</li>
-            <li>5 not supported</li>
-            <li>34 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 30 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>19</td>
+              <td>19</td>
+              <td>0</td>
+              <td>19</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>2</td>
+              <td>0</td>
+              <td>0</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>2</td>
+              <td>1</td>
+              <td>0</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>2</td>
+              <td>5</td>
+              <td>25</td>
+              <td>2</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2073,16 +2106,49 @@
         </h3>
 
         <div id="success_criteria_level_aa-summary">
-          <p>
-            Conformance to the 20 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>20 supported</li>
-            <li>9 partially supported</li>
-            <li>3 not supported</li>
-            <li>16 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 20 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>5</td>
+              <td>8</td>
+              <td>0</td>
+              <td>7</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>5</td>
+              <td>0</td>
+              <td>0</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>1</td>
+              <td>1</td>
+              <td>0</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>2</td>
+              <td>4</td>
+              <td>10</td>
+              <td>0</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -3065,16 +3131,49 @@
         </div>
 
         <div id="success_criteria_level_aaa-summary">
-          <p>
-            Conformance to the 28 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>7 supported</li>
-            <li>1 partially supported</li>
-            <li>0 not supported</li>
-            <li>14 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 28 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>7</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>1</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>14</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -3876,16 +3975,34 @@
         </div>
 
         <div id="functional_performance_criteria-summary">
-          <p>
-            Conformance to the 9 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>5 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>4 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 9 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>5</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>4</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -4212,16 +4329,34 @@
         </div>
 
         <div id="support_documentation_and_services-summary">
-          <p>
-            Conformance to the 5 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>0 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>4 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 5 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>4</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">

--- a/openacr/drupal-9.markdown
+++ b/openacr/drupal-9.markdown
@@ -62,12 +62,14 @@ The terms used in the Conformance Level information are defined as follows:
 
 Notes: Drupal doesn&#x27;t make a strong distinction between the front-end &amp;amp; back-end accessibility. Many administration interfaces can be exposed to users in a more interactive site. Generally this report focuses the Conformance Level / Remarks and Explainations so that Web comments are about elements that are typically public, while Authoring Tool is typically for authors and administrators. The goal of the authoring interface is to support ATAG 2.0 AA (Part A and B). The Drupal community strives to beek up with the latest WCAG recommendation.
 
-Conformance to the 30 criteria listed below is distributed as follows:
+Conformance to the 30 criteria listed below is distributed within each category as follows:
 
-- 57 supported
-- 4 partially supported
-- 5 not supported
-- 34 not applicable
+| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
+| ------------------ | --- | -------------------- | -------- | -------------- |
+| Supports           | 19  | 19                   | 0        | 19             |
+| Partially Supports | 2   | 0                    | 0        | 2              |
+| Does Not Support   | 2   | 1                    | 0        | 2              |
+| Not Applicable     | 2   | 5                    | 25       | 2              |
 
 | Criteria                                                                                                                                       | Conformance Level                                                                                                                                                                 | Remarks and Explanations                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -104,12 +106,14 @@ Conformance to the 30 criteria listed below is distributed as follows:
 
 ### Table 2: Success Criteria, Level AA
 
-Conformance to the 20 criteria listed below is distributed as follows:
+Conformance to the 20 criteria listed below is distributed within each category as follows:
 
-- 20 supported
-- 9 partially supported
-- 3 not supported
-- 16 not applicable
+| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
+| ------------------ | --- | -------------------- | -------- | -------------- |
+| Supports           | 5   | 8                    | 0        | 7              |
+| Partially Supports | 5   | 0                    | 0        | 4              |
+| Does Not Support   | 1   | 1                    | 0        | 1              |
+| Not Applicable     | 2   | 4                    | 10       | 0              |
 
 | Criteria                                                                                                               | Conformance Level                                                                                                                                                                   | Remarks and Explanations                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -138,12 +142,14 @@ Conformance to the 20 criteria listed below is distributed as follows:
 
 Notes: Where possible the Drupal community strives to exceed AA compliance.
 
-Conformance to the 28 criteria listed below is distributed as follows:
+Conformance to the 28 criteria listed below is distributed within each category as follows:
 
-- 7 supported
-- 1 partially supported
-- 0 not supported
-- 14 not applicable
+| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
+| ------------------ | --- | -------------------- | -------- | -------------- |
+| Supports           | 7   | 0                    | 0        | 0              |
+| Partially Supports | 1   | 0                    | 0        | 0              |
+| Does Not Support   | 0   | 0                    | 0        | 0              |
+| Not Applicable     | 14  | 0                    | 0        | 0              |
 
 | Criteria                                                                                                               | Conformance Level                              | Remarks and Explanations                                                                                                                               |
 | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -182,12 +188,14 @@ Conformance to the 28 criteria listed below is distributed as follows:
 
 Notes: Not applicable.
 
-Conformance to the 9 criteria listed below is distributed as follows:
+Conformance to the 9 criteria listed below is distributed within each category as follows:
 
-- 5 supported
-- 0 partially supported
-- 0 not supported
-- 4 not applicable
+| Conformance Level  | All |
+| ------------------ | --- |
+| Supports           | 5   |
+| Partially Supports | 0   |
+| Does Not Support   | 0   |
+| Not Applicable     | 4   |
 
 | Criteria                                                                                                  | Conformance Level                 | Remarks and Explanations                                                                           |
 | --------------------------------------------------------------------------------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------- |
@@ -213,12 +221,14 @@ Notes: Drupal is a web application. Software accessibility criteria is not appli
 
 Notes: Drupal is a web application and all support documentation is delivered through the web. Additional documentation and services are not available.
 
-Conformance to the 5 criteria listed below is distributed as follows:
+Conformance to the 5 criteria listed below is distributed within each category as follows:
 
-- 0 supported
-- 0 partially supported
-- 0 not supported
-- 4 not applicable
+| Conformance Level  | All |
+| ------------------ | --- |
+| Supports           | 0   |
+| Partially Supports | 0   |
+| Does Not Support   | 0   |
+| Not Applicable     | 4   |
 
 | Criteria                                                                                                    | Conformance Level                 | Remarks and Explanations |
 | ----------------------------------------------------------------------------------------------------------- | --------------------------------- | ------------------------ |

--- a/openacr/govready-0.9.html
+++ b/openacr/govready-0.9.html
@@ -380,16 +380,49 @@
         </div>
 
         <div id="success_criteria_level_a-summary">
-          <p>
-            Conformance to the 25 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>32 supported</li>
-            <li>9 partially supported</li>
-            <li>7 not supported</li>
-            <li>52 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 25 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>8</td>
+              <td>12</td>
+              <td>0</td>
+              <td>12</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>7</td>
+              <td>2</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>3</td>
+              <td>3</td>
+              <td>0</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>7</td>
+              <td>8</td>
+              <td>25</td>
+              <td>12</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -1905,16 +1938,49 @@
         </h3>
 
         <div id="success_criteria_level_aa-summary">
-          <p>
-            Conformance to the 13 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>10 supported</li>
-            <li>5 partially supported</li>
-            <li>2 not supported</li>
-            <li>30 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 13 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>Web</th>
+                <th>Electronic Documents</th>
+                <th>Software</th>
+                <th>Authoring Tool</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>3</td>
+              <td>5</td>
+              <td>0</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>3</td>
+              <td>2</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>2</td>
+              <td>0</td>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>5</td>
+              <td>6</td>
+              <td>10</td>
+              <td>9</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2657,16 +2723,34 @@
         </div>
 
         <div id="functional_performance_criteria-summary">
-          <p>
-            Conformance to the 9 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>2 supported</li>
-            <li>0 partially supported</li>
-            <li>3 not supported</li>
-            <li>4 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 9 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>3</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>4</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">
@@ -2999,16 +3083,34 @@
         </div>
 
         <div id="support_documentation_and_services-summary">
-          <p>
-            Conformance to the 4 criteria listed below is distributed as
-            follows:
-          </p>
-          <ul>
-            <li>0 supported</li>
-            <li>0 partially supported</li>
-            <li>0 not supported</li>
-            <li>4 not applicable</li>
-          </ul>
+          <table class="usa-table">
+            <caption>
+              Conformance to the 4 criteria listed below is distributed within
+              each category as follows:
+            </caption>
+            <thead>
+              <tr>
+                <th>Conformance Level</th>
+                <th>All</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Partially Supports</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Does Not Support</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <td>Not Applicable</td>
+              <td>4</td>
+            </tr>
+          </table>
         </div>
 
         <table class="usa-table">

--- a/openacr/govready-0.9.markdown
+++ b/openacr/govready-0.9.markdown
@@ -69,12 +69,14 @@ The terms used in the Conformance Level information are defined as follows:
 
 Notes: GovReady-Q is a web application and an authoring tool. As such the Software &amp; Authoring Tool Notes are all included within the Web for the &#x27;Conformance Level&#x27; and &#x27;Remarks and Explanations&#x27;. There are some elements here that clearly fail WCAG 2.0 A.
 
-Conformance to the 25 criteria listed below is distributed as follows:
+Conformance to the 25 criteria listed below is distributed within each category as follows:
 
-- 32 supported
-- 9 partially supported
-- 7 not supported
-- 52 not applicable
+| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
+| ------------------ | --- | -------------------- | -------- | -------------- |
+| Supports           | 8   | 12                   | 0        | 12             |
+| Partially Supports | 7   | 2                    | 0        | 0              |
+| Does Not Support   | 3   | 3                    | 0        | 1              |
+| Not Applicable     | 7   | 8                    | 25       | 12             |
 
 | Criteria                                                                                                           | Conformance Level                                                                                                                                                                   | Remarks and Explanations                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -106,12 +108,14 @@ Conformance to the 25 criteria listed below is distributed as follows:
 
 ### Table 2: Success Criteria, Level AA
 
-Conformance to the 13 criteria listed below is distributed as follows:
+Conformance to the 13 criteria listed below is distributed within each category as follows:
 
-- 10 supported
-- 5 partially supported
-- 2 not supported
-- 30 not applicable
+| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
+| ------------------ | --- | -------------------- | -------- | -------------- |
+| Supports           | 3   | 5                    | 0        | 2              |
+| Partially Supports | 3   | 2                    | 0        | 0              |
+| Does Not Support   | 2   | 0                    | 0        | 0              |
+| Not Applicable     | 5   | 6                    | 10       | 9              |
 
 | Criteria                                                                                                      | Conformance Level                                                                                                                                                                   | Remarks and Explanations                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -135,12 +139,14 @@ Conformance to the 13 criteria listed below is distributed as follows:
 
 Notes: Not applicable.
 
-Conformance to the 9 criteria listed below is distributed as follows:
+Conformance to the 9 criteria listed below is distributed within each category as follows:
 
-- 2 supported
-- 0 partially supported
-- 3 not supported
-- 4 not applicable
+| Conformance Level  | All |
+| ------------------ | --- |
+| Supports           | 2   |
+| Partially Supports | 0   |
+| Does Not Support   | 3   |
+| Not Applicable     | 4   |
 
 | Criteria                                                                                                  | Conformance Level                   | Remarks and Explanations                                                                                                                               |
 | --------------------------------------------------------------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -166,12 +172,14 @@ Notes: GovReady is a web application. Software accessibility criteria is not app
 
 Notes: GovReady is a web application and all support documentation is delivered through the web. Additional documentation and services are not available.
 
-Conformance to the 4 criteria listed below is distributed as follows:
+Conformance to the 4 criteria listed below is distributed within each category as follows:
 
-- 0 supported
-- 0 partially supported
-- 0 not supported
-- 4 not applicable
+| Conformance Level  | All |
+| ------------------ | --- |
+| Supports           | 0   |
+| Partially Supports | 0   |
+| Does Not Support   | 0   |
+| Not Applicable     | 4   |
 
 | Criteria                                                                                                    | Conformance Level                 | Remarks and Explanations |
 | ----------------------------------------------------------------------------------------------------------- | --------------------------------- | ------------------------ |

--- a/openacr/reports.js
+++ b/openacr/reports.js
@@ -1,9 +1,9 @@
 const dataSet = [
   [
-    "<a href='drupal-10-15-simple.html'>Drupal 10 Accessibility Conformance Report</a>",
+    "<a href='drupal-10-16-simple.html'>Drupal 10 Accessibility Conformance Report</a>",
     "Content Management System",
     "Drupal 10",
-    "<a href='drupal-10-15.yaml'>drupal-10-15.yaml</a>",
+    "<a href='drupal-10-16.yaml'>drupal-10-16.yaml</a>",
   ],
   [
     "<a href='drupal-9.html'>Drupal 9 Accessibility Conformance Report</a>",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "generate-WCAG21508-catalog": "npx ts-node src/librarian.ts -c WCAG21508",
     "a11y-test": "pa11y-ci openacr/*.html output/*.html tests/examples/*.html",
     "generate-license-report": "license-checker-rseidelsohn --relativeLicensePath --relativeModulePath > license/licenses.txt",
-    "generate-drupal-10-html": "npx ts-node src/openacr.ts output -f openacr/drupal-10-15.yaml -c catalog/2.4-edition-wcag-2.1-en.yaml -o openacr/drupal-10-15.html",
-    "generate-drupal-10-simple": "npx ts-node src/openacr.ts output -f openacr/drupal-10-15.yaml -c catalog/2.4-edition-wcag-2.1-en.yaml -o openacr/drupal-10-15-simple.html -t templates/openacr-simple-html-0.1.0.handlebars"
+    "generate-drupal-10-html": "npx ts-node src/openacr.ts output -f openacr/drupal-10-16.yaml -c catalog/2.4-edition-wcag-2.1-en.yaml -o openacr/drupal-10-16.html",
+    "generate-drupal-10-simple": "npx ts-node src/openacr.ts output -f openacr/drupal-10-16.yaml -c catalog/2.4-edition-wcag-2.1-en.yaml -o openacr/drupal-10-16-simple.html -t templates/openacr-simple-html-0.1.0.handlebars"
   },
   "main": "./dist/openacr.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openacr/openacr",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "OpenACR schema validator and output generator",
   "repository": "GSA/openacr",
   "license": "CC0-1.0",

--- a/templates/openacr-html-0.1.0.handlebars
+++ b/templates/openacr-html-0.1.0.handlebars
@@ -138,12 +138,12 @@
               {{#unless data-category.disabled}}
               {{#if data-category.criteria}}
                 <div id="{{catalog-chapter.id}}-summary">
-                  <p>
-                    Conformance to the {{data-category.criteria.length}} criteria listed below is distributed as follows:
-                  </p>
-                  <ul>
+                  <table class="usa-table">
+                    <caption>
+                      Conformance to the {{data-category.criteria.length}} criteria listed below is distributed within each category as follows:
+                    </caption>
                     {{progressPerChapter data-category.criteria}}
-                  </ul>
+                  </table>
                 </div>
 
                 <table class="usa-table">

--- a/templates/openacr-markdown-0.1.0.handlebars
+++ b/templates/openacr-markdown-0.1.0.handlebars
@@ -80,7 +80,7 @@ Notes: {{data-category.notes}}
 
 {{#unless data-category.disabled}}
 {{#if data-category.criteria}}
-Conformance to the {{data-category.criteria.length}} criteria listed below is distributed as follows:
+Conformance to the {{data-category.criteria.length}} criteria listed below is distributed within each category as follows:
 
 {{progressPerChapter data-category.criteria}}
 

--- a/templates/openacr-simple-html-0.1.0.handlebars
+++ b/templates/openacr-simple-html-0.1.0.handlebars
@@ -114,6 +114,7 @@
 
     table {
        border-collapse: collapse;
+       margin: 10px 0;
      }
     th, td {
       border: 1px solid #000;
@@ -247,12 +248,12 @@
               {{#unless data-category.disabled}}
               {{#if data-category.criteria}}
                 <div id="{{catalog-chapter.id}}-summary">
-                  <p>
-                    Conformance to the {{data-category.criteria.length}} criteria listed below is distributed as follows:
-                  </p>
-                  <ul>
+                  <table class="usa-table">
+                    <caption>
+                      Conformance to the {{data-category.criteria.length}} criteria listed below is distributed within each category as follows:
+                    </caption>
                     {{progressPerChapter data-category.criteria}}
-                  </ul>
+                  </table>
                 </div>
 
                 <table class="usa-table">

--- a/tests/examples/valid-missing-one-component.yaml
+++ b/tests/examples/valid-missing-one-component.yaml
@@ -1,0 +1,32 @@
+title: Lorem Ipsum Accessibility Conformance Report
+product:
+  name: Lorem Ipsum
+  version: "1.1"
+  description: Fake text
+author:
+  email: cicero@example.com
+notes: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet viverra lorem. Nullam laoreet vitae lorem et semper. Donec feugiat rutrum luctus. Nunc nec scelerisque orci. Mauris non tellus congue, vestibulum felis at, consectetur dui. Aenean luctus dictum diam. Vestibulum vehicula leo nulla, nec hendrerit felis sodales a. In hac habitasse platea dictumst. Phasellus odio felis, efficitur a mattis vitae, fermentum vitae libero. Nam ut magna id sem pellentesque ultrices. Nulla sed urna vel tortor vehicula varius. Sed scelerisque porta nisi, sit amet ultricies ante ullamcorper quis.
+chapters:
+  success_criteria_level_a:
+    criteria:
+      - num: "1.1.1"
+        components:
+          - name: "web"
+            adherence:
+              level: "supports"
+              notes: Cras ultrices, diam in laoreet condimentum, purus leo tempor erat, eu facilisis erat tortor at purus.
+          - name: "electronic-docs"
+            adherence:
+              level: "supports"
+              notes: Curabitur tristique tellus quis ligula elementum, sit amet tincidunt est aliquet.
+          - name: "software"
+            adherence:
+              level: "not-applicable"
+      - num: "1.2.2"
+        components:
+          - name: "authoring-tool"
+            adherence:
+              level: "supports"
+              notes: Vestibulum sit amet tortor ac nunc rutrum consequat vel sit amet risus. Nam eget mollis odio, sit amet bibendum mi. Quisque ac neque a nulla dapibus imperdiet.
+  hardware:
+    notes: "Lorem Ipsum is a web application. Hardware accessibility criteria is not applicable."

--- a/tests/examples/valid.html
+++ b/tests/examples/valid.html
@@ -274,15 +274,12 @@
 
 
                 <div id="success_criteria_level_a-summary">
-                  <p>
-                    Conformance to the 2 criteria listed below is distributed as follows:
-                  </p>
-                  <ul>
-                    <li>3 supported</li>
-        <li>2 partially supported</li>
-        <li>1 not supported</li>
-        <li>2 not applicable</li>
-                  </ul>
+                  <table class="usa-table">
+                    <caption>
+                      Conformance to the 2 criteria listed below is distributed within each category as follows:
+                    </caption>
+                    <thead><tr><th>Conformance Level</th><th>Web</th><th>Electronic Documents</th><th>Software</th><th>Authoring Tool</th></tr></thead><tr><td>Supports</td><td>1</td><td>1</td><td>0</td><td>1</td></tr><tr><td>Partially Supports</td><td>1</td><td>1</td><td>0</td><td>0</td></tr><tr><td>Does Not Support</td><td>0</td><td>0</td><td>0</td><td>1</td></tr><tr><td>Not Applicable</td><td>0</td><td>0</td><td>2</td><td>0</td></tr>
+                  </table>
                 </div>
 
                 <table class="usa-table">

--- a/tests/examples/valid.markdown
+++ b/tests/examples/valid.markdown
@@ -56,12 +56,15 @@ The terms used in the Conformance Level information are defined as follows:
 ### Table 1: Success Criteria, Level A
 
 
-Conformance to the 2 criteria listed below is distributed as follows:
+Conformance to the 2 criteria listed below is distributed within each category as follows:
 
-- 3 supported
-- 2 partially supported
-- 1 not supported
-- 2 not applicable
+| Conformance Level | Web | Electronic Documents | Software | Authoring Tool |
+| --- | --- | --- | --- | --- |
+| Supports | 1 | 1 | 0 | 1 |
+| Partially Supports | 1 | 1 | 0 | 0 |
+| Does Not Support | 0 | 0 | 0 | 1 |
+| Not Applicable | 0 | 0 | 2 | 0 |
+
 
 | Criteria | Conformance Level | Remarks and Explanations |
 | --- | --- | --- |

--- a/tests/openacr-output-cli.test.ts
+++ b/tests/openacr-output-cli.test.ts
@@ -111,6 +111,58 @@ describe("OpenACR CLI test output", () => {
     });
   });
 
+  it("when passed example file with one missing component and valid catalog file should return valid output message", () => {
+    const valid = spawn(
+      cmd,
+      options.concat(
+        "tests/examples/valid-missing-one-component.yaml",
+        "-c",
+        "catalog/2.4-edition-wcag-2.0-508-en.yaml",
+        "-o",
+        "output/valid-missing-one-component.html"
+      )
+    );
+    const chunks = [];
+
+    valid.stdout.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+
+    valid.stdout.on("end", () => {
+      const output = Buffer.concat(chunks).toString();
+
+      expect(output).to.equal(
+        "Valid and output generated at output/valid-missing-one-component.html!\n"
+      );
+    });
+  });
+
+  it("when passed example file with one missing component and valid catalog file should return valid output message, markdown example", () => {
+    const valid = spawn(
+      cmd,
+      options.concat(
+        "tests/examples/valid-missing-one-component.yaml",
+        "-c",
+        "catalog/2.4-edition-wcag-2.0-508-en.yaml",
+        "-o",
+        "output/valid-missing-one-component.markdown"
+      )
+    );
+    const chunks = [];
+
+    valid.stdout.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+
+    valid.stdout.on("end", () => {
+      const output = Buffer.concat(chunks).toString();
+
+      expect(output).to.equal(
+        "Valid and output generated at output/valid-missing-one-component.markdown!\n"
+      );
+    });
+  });
+
   it("when passed file that has components with missing adherence and valid catalog file should return valid output message", () => {
     const valid = spawn(
       cmd,


### PR DESCRIPTION
Sharing some changes we made last year to the output of the ACR. Instead of the roll-up of conformance to be a list, it is a table. See https://civicactions.github.io/openacr/drupal-10-16.html#success_criteria_level_a and here is an example: 

**Previously:**

Conformance to the 30 criteria listed below is distributed as follows:

- 57 supported
- 4 partially supported
- 5 not supported
- 34 not applicable

**After the changes:**

Conformance to the 30 criteria listed below is distributed within each category as follows:

| Conformance Level  | Web | Electronic Documents | Software | Authoring Tool |
| ------------------ | --- | -------------------- | -------- | -------------- |
| Supports           | 19  | 19                   | 0        | 19             |
| Partially Supports | 2   | 0                    | 0        | 2              |
| Does Not Support   | 2   | 1                    | 0        | 2              |
| Not Applicable     | 2   | 5                    | 25       | 2              |


Also updating the stored examples with the above changes and latest ACR for Drupal.