### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -3,6 +3,9 @@ name: OpenACR output accessibility testing
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     name: Building app, generate output examples and test for accessibility issues

--- a/.github/workflows/backlog-issues.yaml
+++ b/.github/workflows/backlog-issues.yaml
@@ -6,6 +6,11 @@ on:
       - reopened
       - opened
 
+permissions:
+  contents: read
+  issues: write
+  repository-projects: write
+
 jobs:
   triage_issues:
     if: github.repository == 'GSA/openacr'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/openacr-export.yaml
+++ b/.github/workflows/openacr-export.yaml
@@ -3,6 +3,9 @@ name: OpenACR Export
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     name: Building app and generate export of all reports including the data table.

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -3,6 +3,9 @@ name: pre-commit
 on:
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,9 @@ name: tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     name: Building app and run our tests


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks across workflows missing token scopes:
  - `.github/workflows/a11y.yaml`
  - `.github/workflows/backlog-issues.yaml`
  - `.github/workflows/main.yml`
  - `.github/workflows/openacr-export.yaml`
  - `.github/workflows/pre-commit.yaml`
  - `.github/workflows/tests.yaml`
- Use least-privilege per workflow behavior:
  - `contents: read` for read-only/test workflows
  - `contents: write` for workflows that push updates
  - `issues: write` and `repository-projects: write` for issue/project-board automation

## Why
This resolves missing-permissions findings and prevents over-broad default token access while preserving existing automation behavior.